### PR TITLE
HFP 74 feat job posting service

### DIFF
--- a/freebridge/common/src/main/java/com/fallguys/common/exception/ErrorCode.java
+++ b/freebridge/common/src/main/java/com/fallguys/common/exception/ErrorCode.java
@@ -26,7 +26,8 @@ public enum ErrorCode {
     JOB_POSTING_NOT_FOUND(404, "JP001", "공고를 찾지 못 했습니다."),
     JOB_POSTING_FORBIDDEN(403, "JP002", "권한이 없습니다."),
     JOB_POSTING_ALREADY_DELETED(409, "JP003", "이미 삭제된 공고입니다."),
-    ONLY_EMPLOYER_ALLOWED(403, "JP004", "employer만 가능합니다.");
+    ONLY_EMPLOYER_ALLOWED(403, "JP004", "employer만 가능합니다."),
+    ONLY_FREELANCER_ALLOWED(403, "JP005", "freelancer만 가능합니다.");
 
     private final int status;
     private final String code;

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/JobPostingEmployerController.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/JobPostingEmployerController.java
@@ -5,6 +5,7 @@ import com.fallguys.recruitment.api.dto.request.JobPostingCreateDTO;
 import com.fallguys.recruitment.api.dto.request.JobPostingUpdateDTO;
 import com.fallguys.recruitment.api.dto.response.JobPostingSearchDTO;
 import com.fallguys.recruitment.api.dto.response.PagedResponseDTO;
+import com.fallguys.recruitment.api.util.PagingUtils;
 import com.fallguys.recruitment.service.JobPostingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -31,7 +32,7 @@ public class JobPostingEmployerController {
             @RequestParam(defaultValue = "10") int size
     ) {
         List<JobPostingSearchDTO> result = jobPostingService.getJobPostings(employerId);
-        return ResponseEntity.ok(ApiResponse.ok(toPagedResponse(result, page, size)));
+        return ResponseEntity.ok(ApiResponse.ok(PagingUtils.toPagedResponse(result, page, size)));
     }
 
     @PostMapping("/api/v1/employer/jobs/post")
@@ -60,21 +61,5 @@ public class JobPostingEmployerController {
     ) {
         jobPostingService.deleteJobPosting(jobsNumber, employerId);
         return ResponseEntity.ok(ApiResponse.ok(null));
-    }
-
-    private <T> PagedResponseDTO<T> toPagedResponse(List<T> source, int page, int size) {
-        int safePage = Math.max(page, 0);
-        int safeSize = Math.max(size, 1);
-        int fromIndex = Math.min(safePage * safeSize, source.size());
-        int toIndex = Math.min(fromIndex + safeSize, source.size());
-        int totalPages = (int) Math.ceil((double) source.size() / safeSize);
-
-        return new PagedResponseDTO<>(
-                source.subList(fromIndex, toIndex),
-                safePage,
-                safeSize,
-                source.size(),
-                totalPages
-        );
     }
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/JobPostingEmployerController.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/JobPostingEmployerController.java
@@ -13,20 +13,18 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/employer/jobs")
 @RequiredArgsConstructor
 public class JobPostingEmployerController {
 
     private final JobPostingService jobPostingService;
 
-    @GetMapping("/")
+    @GetMapping("/api/v1/employer/jobs/")
     public ResponseEntity<ApiResponse<PagedResponseDTO<JobPostingSearchDTO>>> getMyJobPostings(
             @RequestParam Long employerId,
             @RequestParam(defaultValue = "0") int page,
@@ -36,7 +34,7 @@ public class JobPostingEmployerController {
         return ResponseEntity.ok(ApiResponse.ok(toPagedResponse(result, page, size)));
     }
 
-    @PostMapping("/post")
+    @PostMapping("/api/v1/employer/jobs/post")
     public ResponseEntity<ApiResponse<Void>> createJobPosting(
             @RequestParam Long employerId,
             @RequestBody JobPostingCreateDTO request
@@ -45,7 +43,7 @@ public class JobPostingEmployerController {
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
-    @PutMapping("/put")
+    @PutMapping("/api/v1/employer/jobs/put")
     public ResponseEntity<ApiResponse<Void>> updateJobPosting(
             @RequestParam(name = "jobsNumber") Long jobsNumber,
             @RequestParam Long employerId,
@@ -55,7 +53,7 @@ public class JobPostingEmployerController {
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
-    @DeleteMapping("/del")
+    @DeleteMapping("/api/v1/employer/jobs/del")
     public ResponseEntity<ApiResponse<Void>> deleteJobPosting(
             @RequestParam(name = "jobsNumber") Long jobsNumber,
             @RequestParam Long employerId

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/JobPostingEmployerController.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/JobPostingEmployerController.java
@@ -1,15 +1,18 @@
 package com.fallguys.recruitment.api;
 
 import com.fallguys.common.response.ApiResponse;
-import com.fallguys.recruitment.api.dto.response.FreelancerJobPostingSearchDTO;
+import com.fallguys.recruitment.api.dto.request.JobPostingCreateDTO;
+import com.fallguys.recruitment.api.dto.request.JobPostingUpdateDTO;
+import com.fallguys.recruitment.api.dto.response.JobPostingSearchDTO;
 import com.fallguys.recruitment.api.dto.response.PagedResponseDTO;
 import com.fallguys.recruitment.service.JobPostingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,42 +20,47 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/freelancer/jobs")
+@RequestMapping("/api/v1/employer/jobs")
 @RequiredArgsConstructor
-public class JobPostingFreelancerController {
+public class JobPostingEmployerController {
 
     private final JobPostingService jobPostingService;
 
-    @GetMapping
-    public ResponseEntity<ApiResponse<PagedResponseDTO<FreelancerJobPostingSearchDTO>>> searchJobPostings(
-            @RequestParam Long freelancerId,
-            @RequestParam(required = false) String keyword,
-            @RequestParam(name = "liked", defaultValue = "false") boolean liked,
+    @GetMapping("/")
+    public ResponseEntity<ApiResponse<PagedResponseDTO<JobPostingSearchDTO>>> getMyJobPostings(
+            @RequestParam Long employerId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        List<FreelancerJobPostingSearchDTO> result =
-                jobPostingService.searchJobPostingsForFreelancer(freelancerId, keyword, liked);
-        PagedResponseDTO<FreelancerJobPostingSearchDTO> paged = toPagedResponse(result, page, size);
-
-        return ResponseEntity.ok(ApiResponse.ok(paged));
+        List<JobPostingSearchDTO> result = jobPostingService.getJobPostings(employerId);
+        return ResponseEntity.ok(ApiResponse.ok(toPagedResponse(result, page, size)));
     }
 
-    @PostMapping("/{jobPostingId}/like")
-    public ResponseEntity<ApiResponse<Void>> addFavorite(
-            @RequestParam Long freelancerId,
-            @PathVariable Long jobPostingId
+    @PostMapping("/post")
+    public ResponseEntity<ApiResponse<Void>> createJobPosting(
+            @RequestParam Long employerId,
+            @RequestBody JobPostingCreateDTO request
     ) {
-        jobPostingService.addFavoriteJobPosting(freelancerId, jobPostingId);
+        jobPostingService.createJobPosting(request, employerId);
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
-    @DeleteMapping("/{jobPostingId}/like")
-    public ResponseEntity<ApiResponse<Void>> removeFavorite(
-            @RequestParam Long freelancerId,
-            @PathVariable Long jobPostingId
+    @PutMapping("/put")
+    public ResponseEntity<ApiResponse<Void>> updateJobPosting(
+            @RequestParam(name = "jobsNumber") Long jobsNumber,
+            @RequestParam Long employerId,
+            @RequestBody JobPostingUpdateDTO request
     ) {
-        jobPostingService.removeFavoriteJobPosting(freelancerId, jobPostingId);
+        jobPostingService.updateJobPosting(request, jobsNumber, employerId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @DeleteMapping("/del")
+    public ResponseEntity<ApiResponse<Void>> deleteJobPosting(
+            @RequestParam(name = "jobsNumber") Long jobsNumber,
+            @RequestParam Long employerId
+    ) {
+        jobPostingService.deleteJobPosting(jobsNumber, employerId);
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/JobPostingEmployerController.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/JobPostingEmployerController.java
@@ -24,7 +24,7 @@ public class JobPostingEmployerController {
 
     private final JobPostingService jobPostingService;
 
-    @GetMapping("/api/v1/employer/jobs/")
+    @GetMapping("/api/v1/employer/jobs")
     public ResponseEntity<ApiResponse<PagedResponseDTO<JobPostingSearchDTO>>> getMyJobPostings(
             @RequestParam Long employerId,
             @RequestParam(defaultValue = "0") int page,

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/JobPostingFreelancerController.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/JobPostingFreelancerController.java
@@ -3,6 +3,7 @@ package com.fallguys.recruitment.api;
 import com.fallguys.common.response.ApiResponse;
 import com.fallguys.recruitment.api.dto.response.FreelancerJobPostingSearchDTO;
 import com.fallguys.recruitment.api.dto.response.PagedResponseDTO;
+import com.fallguys.recruitment.api.util.PagingUtils;
 import com.fallguys.recruitment.service.JobPostingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -31,7 +32,7 @@ public class JobPostingFreelancerController {
     ) {
         List<FreelancerJobPostingSearchDTO> result =
                 jobPostingService.searchJobPostingsForFreelancer(freelancerId, keyword, liked);
-        PagedResponseDTO<FreelancerJobPostingSearchDTO> paged = toPagedResponse(result, page, size);
+        PagedResponseDTO<FreelancerJobPostingSearchDTO> paged = PagingUtils.toPagedResponse(result, page, size);
 
         return ResponseEntity.ok(ApiResponse.ok(paged));
     }
@@ -52,21 +53,5 @@ public class JobPostingFreelancerController {
     ) {
         jobPostingService.removeFavoriteJobPosting(freelancerId, jobPostingId);
         return ResponseEntity.ok(ApiResponse.ok(null));
-    }
-
-    private <T> PagedResponseDTO<T> toPagedResponse(List<T> source, int page, int size) {
-        int safePage = Math.max(page, 0);
-        int safeSize = Math.max(size, 1);
-        int fromIndex = Math.min(safePage * safeSize, source.size());
-        int toIndex = Math.min(fromIndex + safeSize, source.size());
-        int totalPages = (int) Math.ceil((double) source.size() / safeSize);
-
-        return new PagedResponseDTO<>(
-                source.subList(fromIndex, toIndex),
-                safePage,
-                safeSize,
-                source.size(),
-                totalPages
-        );
     }
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/JobPostingFreelancerController.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/JobPostingFreelancerController.java
@@ -10,20 +10,18 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/freelancer/jobs")
 @RequiredArgsConstructor
 public class JobPostingFreelancerController {
 
     private final JobPostingService jobPostingService;
 
-    @GetMapping
+    @GetMapping("/api/v1/freelancer/jobs")
     public ResponseEntity<ApiResponse<PagedResponseDTO<FreelancerJobPostingSearchDTO>>> searchJobPostings(
             @RequestParam Long freelancerId,
             @RequestParam(required = false) String keyword,
@@ -38,7 +36,7 @@ public class JobPostingFreelancerController {
         return ResponseEntity.ok(ApiResponse.ok(paged));
     }
 
-    @PostMapping("/{jobPostingId}/like")
+    @PostMapping("/api/v1/freelancer/jobs/{jobPostingId}/like")
     public ResponseEntity<ApiResponse<Void>> addFavorite(
             @RequestParam Long freelancerId,
             @PathVariable Long jobPostingId
@@ -47,7 +45,7 @@ public class JobPostingFreelancerController {
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
-    @DeleteMapping("/{jobPostingId}/like")
+    @DeleteMapping("/api/v1/freelancer/jobs/{jobPostingId}/like")
     public ResponseEntity<ApiResponse<Void>> removeFavorite(
             @RequestParam Long freelancerId,
             @PathVariable Long jobPostingId

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/JobPostingFreelancerController.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/JobPostingFreelancerController.java
@@ -1,0 +1,54 @@
+package com.fallguys.recruitment.api;
+
+import com.fallguys.common.response.ApiResponse;
+import com.fallguys.recruitment.api.dto.response.FreelancerJobPostingSearchDTO;
+import com.fallguys.recruitment.service.JobPostingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/freelancers/job-postings")
+@RequiredArgsConstructor
+public class JobPostingFreelancerController {
+
+    private final JobPostingService jobPostingService;
+
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<List<FreelancerJobPostingSearchDTO>>> searchJobPostings(
+            @RequestParam Long freelancerId,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "false") boolean favoritesOnly
+    ) {
+        List<FreelancerJobPostingSearchDTO> result =
+                jobPostingService.searchJobPostingsForFreelancer(freelancerId, keyword, favoritesOnly);
+
+        return ResponseEntity.ok(ApiResponse.ok(result));
+    }
+
+    @PostMapping("/{jobPostingId}/favorites")
+    public ResponseEntity<ApiResponse<Void>> addFavorite(
+            @RequestParam Long freelancerId,
+            @PathVariable Long jobPostingId
+    ) {
+        jobPostingService.addFavoriteJobPosting(freelancerId, jobPostingId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @DeleteMapping("/{jobPostingId}/favorites")
+    public ResponseEntity<ApiResponse<Void>> removeFavorite(
+            @RequestParam Long freelancerId,
+            @PathVariable Long jobPostingId
+    ) {
+        jobPostingService.removeFavoriteJobPosting(freelancerId, jobPostingId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+}

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/request/JobPostingCreateDTO.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/request/JobPostingCreateDTO.java
@@ -1,18 +1,16 @@
 package com.fallguys.recruitment.api.dto.request;
 
 import com.fallguys.recruitment.entity.JobPostingStatus;
-import lombok.Getter;
 
 import java.util.List;
 
-@Getter
-public class JobPostingCreateDTO {
-    Long employerId;
-    String employerName;
-    String title;
-    String description;
-    JobPostingStatus status;
-    List<String> techStack;
-    Long budget;
-    Integer duration;
+public record JobPostingCreateDTO() {
+    static Long employerId;
+    static String employerName;
+    static String title;
+    static String description;
+    static JobPostingStatus status;
+    static List<String> techStack;
+    static Long budget;
+    static Integer duration;
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/request/JobPostingCreateDTO.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/request/JobPostingCreateDTO.java
@@ -1,16 +1,10 @@
 package com.fallguys.recruitment.api.dto.request;
-
-import com.fallguys.recruitment.entity.JobPostingStatus;
-
 import java.util.List;
 
-public record JobPostingCreateDTO() {
-    static Long employerId;
-    static String employerName;
-    static String title;
-    static String description;
-    static JobPostingStatus status;
-    static List<String> techStack;
-    static Long budget;
-    static Integer duration;
-}
+public record JobPostingCreateDTO(
+        String title,
+        String description,
+        List<String> techStack,
+        Long budget,
+        Integer duration
+) {}

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/request/JobPostingUpdateDTO.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/request/JobPostingUpdateDTO.java
@@ -2,13 +2,9 @@ package com.fallguys.recruitment.api.dto.request;
 
 import com.fallguys.recruitment.entity.JobPostingStatus;
 import lombok.Getter;
-import lombok.Setter;
-
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
-@Setter
 public class JobPostingUpdateDTO {
     String title;
     String description;

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/request/JobPostingUpdateDTO.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/request/JobPostingUpdateDTO.java
@@ -1,15 +1,13 @@
 package com.fallguys.recruitment.api.dto.request;
 
 import com.fallguys.recruitment.entity.JobPostingStatus;
-import lombok.Getter;
 import java.util.List;
 
-@Getter
-public class JobPostingUpdateDTO {
-    String title;
-    String description;
-    List<String> techStack;
-    Long budget;
-    Integer duration;
-    JobPostingStatus status;
+public record JobPostingUpdateDTO() {
+    static String title;
+    static String description;
+    static List<String> techStack;
+    static Long budget;
+    static Integer duration;
+    static JobPostingStatus status;
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/request/JobPostingUpdateDTO.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/request/JobPostingUpdateDTO.java
@@ -3,11 +3,11 @@ package com.fallguys.recruitment.api.dto.request;
 import com.fallguys.recruitment.entity.JobPostingStatus;
 import java.util.List;
 
-public record JobPostingUpdateDTO() {
-    static String title;
-    static String description;
-    static List<String> techStack;
-    static Long budget;
-    static Integer duration;
-    static JobPostingStatus status;
-}
+public record JobPostingUpdateDTO(
+        String title,
+        String description,
+        List<String> techStack,
+        Long budget,
+        Integer duration,
+        JobPostingStatus status
+) {}

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/response/FreelancerJobPostingSearchDTO.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/response/FreelancerJobPostingSearchDTO.java
@@ -1,0 +1,15 @@
+package com.fallguys.recruitment.api.dto.response;
+
+import java.util.List;
+
+public record FreelancerJobPostingSearchDTO(
+        Long jobPostingId,
+        String employerName,
+        String title,
+        String description,
+        List<String> techStack,
+        Long budget,
+        Integer duration,
+        boolean favorite
+) {
+}

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/response/JobPostingSearchDTO.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/response/JobPostingSearchDTO.java
@@ -5,6 +5,8 @@ import com.fallguys.recruitment.entity.JobPostingStatus;
 import java.util.List;
 
 public record JobPostingSearchDTO(
+        Long jobPostingId,
+        String employerName,
         String title,
         String description,
         List<String> techStack,

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/response/JobPostingSearchDTO.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/response/JobPostingSearchDTO.java
@@ -4,11 +4,11 @@ import com.fallguys.recruitment.entity.JobPostingStatus;
 
 import java.util.List;
 
-public record JobPostingSearchDTO() {
-    static String title;
-    static String description;
-    static List<String> techStack;
-    static Long budget;
-    static Integer duration;
-    static JobPostingStatus status;
-}
+public record JobPostingSearchDTO(
+        String title,
+        String description,
+        List<String> techStack,
+        Long budget,
+        Integer duration,
+        JobPostingStatus status
+) {}

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/response/JobPostingSearchDTO.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/response/JobPostingSearchDTO.java
@@ -1,18 +1,14 @@
-package com.fallguys.recruitment.api.dto.request;
+package com.fallguys.recruitment.api.dto.response;
 
 import com.fallguys.recruitment.entity.JobPostingStatus;
-import lombok.Getter;
 
 import java.util.List;
 
-@Getter
-public class JobPostingCreateDTO {
-    Long employerId;
-    String employerName;
+public class JobPostingSearchDTO {
     String title;
     String description;
-    JobPostingStatus status;
     List<String> techStack;
     Long budget;
     Integer duration;
+    JobPostingStatus status;
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/response/JobPostingSearchDTO.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/response/JobPostingSearchDTO.java
@@ -4,11 +4,11 @@ import com.fallguys.recruitment.entity.JobPostingStatus;
 
 import java.util.List;
 
-public class JobPostingSearchDTO {
-    String title;
-    String description;
-    List<String> techStack;
-    Long budget;
-    Integer duration;
-    JobPostingStatus status;
+public record JobPostingSearchDTO() {
+    static String title;
+    static String description;
+    static List<String> techStack;
+    static Long budget;
+    static Integer duration;
+    static JobPostingStatus status;
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/response/PagedResponseDTO.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/response/PagedResponseDTO.java
@@ -1,0 +1,11 @@
+package com.fallguys.recruitment.api.dto.response;
+
+import java.util.List;
+
+public record PagedResponseDTO<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {}

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/util/PagingUtils.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/util/PagingUtils.java
@@ -12,8 +12,11 @@ public final class PagingUtils {
     public static <T> PagedResponseDTO<T> toPagedResponse(List<T> source, int page, int size) {
         int safePage = Math.max(page, 0);
         int safeSize = Math.max(size, 1);
-        int fromIndex = Math.min(safePage * safeSize, source.size());
-        int toIndex = Math.min(fromIndex + safeSize, source.size());
+        long sourceSize = source.size();
+        long startLong = Math.min((long) safePage * (long) safeSize, sourceSize);
+        int fromIndex = (int) startLong;
+        long endLong = Math.min(startLong + (long) safeSize, sourceSize);
+        int toIndex = (int) endLong;
         int totalPages = (int) Math.ceil((double) source.size() / safeSize);
 
         return new PagedResponseDTO<>(

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/util/PagingUtils.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/util/PagingUtils.java
@@ -1,0 +1,27 @@
+package com.fallguys.recruitment.api.util;
+
+import com.fallguys.recruitment.api.dto.response.PagedResponseDTO;
+
+import java.util.List;
+
+public final class PagingUtils {
+
+    private PagingUtils() {
+    }
+
+    public static <T> PagedResponseDTO<T> toPagedResponse(List<T> source, int page, int size) {
+        int safePage = Math.max(page, 0);
+        int safeSize = Math.max(size, 1);
+        int fromIndex = Math.min(safePage * safeSize, source.size());
+        int toIndex = Math.min(fromIndex + safeSize, source.size());
+        int totalPages = (int) Math.ceil((double) source.size() / safeSize);
+
+        return new PagedResponseDTO<>(
+                source.subList(fromIndex, toIndex),
+                safePage,
+                safeSize,
+                source.size(),
+                totalPages
+        );
+    }
+}

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/entity/JobPosting.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/entity/JobPosting.java
@@ -51,27 +51,31 @@ public class JobPosting extends BaseEntity {
         return jobPosting;
     }
 
-    public void update(JobPostingUpdateDTO jobPostingUpdateDTO) {
-        this.title = jobPostingUpdateDTO.getTitle();
-        this.description = jobPostingUpdateDTO.getDescription();
-        this.techStack = jobPostingUpdateDTO.getTechStack() == null
+    public void update(JobPostingUpdateDTO dto) {
+        this.title = dto.title();
+        this.description = dto.description();
+        this.techStack = dto.techStack() == null
                 ? new ArrayList<>()
-                : new ArrayList<>(jobPostingUpdateDTO.getTechStack());
-        this.budget = jobPostingUpdateDTO.getBudget();
-        this.duration = jobPostingUpdateDTO.getDuration();
-        this.postingStatus = jobPostingUpdateDTO.getStatus();
+                : new ArrayList<>(dto.techStack());
+        this.budget = dto.budget();
+        this.duration = dto.duration();
+        this.postingStatus = dto.status();
     }
 
-    private void create(JobPostingCreateDTO jobPostingCreateDTO, Long employerId, String employerName) {
-        this.title = jobPostingCreateDTO.getTitle();
-        this.description = jobPostingCreateDTO.getDescription();
-        this.techStack = jobPostingCreateDTO.getTechStack() == null
+    private void create(JobPostingCreateDTO dto,
+                        Long employerId,
+                        String employerName) {
+
+        this.title = dto.title();
+        this.description = dto.description();
+        this.techStack = dto.techStack() == null
                 ? new ArrayList<>()
-                : new ArrayList<>(jobPostingCreateDTO.getTechStack());
-        this.budget = jobPostingCreateDTO.getBudget();
-        this.duration = jobPostingCreateDTO.getDuration();
+                : new ArrayList<>(dto.techStack());
+        this.budget = dto.budget();
+        this.duration = dto.duration();
         this.postingStatus = JobPostingStatus.OPEN;
-        this.status=Status.ACTIVE;
+        this.status = Status.ACTIVE;
+
         assignEmployer(employerId);
         this.employerName = employerName;
     }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/entity/JobPosting.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/entity/JobPosting.java
@@ -52,14 +52,14 @@ public class JobPosting extends BaseEntity {
     }
 
     public void update(JobPostingUpdateDTO dto) {
-        this.title = dto.title();
-        this.description = dto.description();
+        this.title = dto.title() == null ? this.title : dto.title();
+        this.description = dto.description() == null ? this.description : dto.description();
         this.techStack = dto.techStack() == null
-                ? new ArrayList<>()
+                ? this.techStack
                 : new ArrayList<>(dto.techStack());
-        this.budget = dto.budget();
-        this.duration = dto.duration();
-        this.postingStatus = dto.status();
+        this.budget = dto.budget() == null ? this.budget : dto.budget();
+        this.duration = dto.duration() == null ? this.duration : dto.duration();
+        this.postingStatus = dto.status() == null ? this.postingStatus : dto.status();
     }
 
     private void create(JobPostingCreateDTO dto,

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/entity/JobPostingFavorite.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/entity/JobPostingFavorite.java
@@ -1,0 +1,53 @@
+package com.fallguys.recruitment.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "job_posting_favorite",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_job_posting_favorite_freelancer_posting",
+                columnNames = {"freelancer_id", "job_posting_id"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class JobPostingFavorite {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "freelancer_id", nullable = false)
+    private Long freelancerId;
+
+    @Column(name = "job_posting_id", nullable = false)
+    private Long jobPostingId;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static JobPostingFavorite of(Long freelancerId, Long jobPostingId) {
+        JobPostingFavorite favorite = new JobPostingFavorite();
+        favorite.freelancerId = freelancerId;
+        favorite.jobPostingId = jobPostingId;
+        return favorite;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/repository/JobPostingFavoriteRepo.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/repository/JobPostingFavoriteRepo.java
@@ -1,0 +1,16 @@
+package com.fallguys.recruitment.repository;
+
+import com.fallguys.recruitment.entity.JobPostingFavorite;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface JobPostingFavoriteRepo extends JpaRepository<JobPostingFavorite, Long> {
+    List<JobPostingFavorite> findAllByFreelancerId(Long freelancerId);
+
+    boolean existsByFreelancerIdAndJobPostingId(Long freelancerId, Long jobPostingId);
+
+    void deleteByFreelancerIdAndJobPostingId(Long freelancerId, Long jobPostingId);
+}

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/repository/JobPostingFavoriteRepo.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/repository/JobPostingFavoriteRepo.java
@@ -10,7 +10,5 @@ import java.util.List;
 public interface JobPostingFavoriteRepo extends JpaRepository<JobPostingFavorite, Long> {
     List<JobPostingFavorite> findAllByFreelancerId(Long freelancerId);
 
-    boolean existsByFreelancerIdAndJobPostingId(Long freelancerId, Long jobPostingId);
-
     void deleteByFreelancerIdAndJobPostingId(Long freelancerId, Long jobPostingId);
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/repository/JobPostingRepo.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/repository/JobPostingRepo.java
@@ -1,10 +1,13 @@
 package com.fallguys.recruitment.repository;
 
+import com.fallguys.recruitment.api.dto.response.JobPostingSearchDTO;
 import com.fallguys.recruitment.entity.JobPosting;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface JobPostingRepo extends JpaRepository<JobPosting, Long> {
-
+    List<JobPostingSearchDTO> findAllByEmployerIdAndDeletedFalse(Long EmployerId);
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/repository/JobPostingRepo.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/repository/JobPostingRepo.java
@@ -1,6 +1,7 @@
 package com.fallguys.recruitment.repository;
 
-import com.fallguys.recruitment.api.dto.response.JobPostingSearchDTO;
+import com.fallguys.recruitment.entity.JobPostingStatus;
+import com.fallguys.recruitment.entity.Status;
 import com.fallguys.recruitment.entity.JobPosting;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,5 +10,9 @@ import java.util.List;
 
 @Repository
 public interface JobPostingRepo extends JpaRepository<JobPosting, Long> {
-    List<JobPostingSearchDTO> findAllByEmployerIdAndDeletedFalse(Long EmployerId);
+    List<JobPosting> findAllByEmployerIdAndStatusNot(Long employerId, Status status);
+
+    List<JobPosting> findAllByStatusNot(Status status);
+
+    List<JobPosting> findAllByStatusAndPostingStatus(Status status, JobPostingStatus postingStatus);
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingService.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingService.java
@@ -2,6 +2,7 @@ package com.fallguys.recruitment.service;
 
 import com.fallguys.recruitment.api.dto.request.JobPostingCreateDTO;
 import com.fallguys.recruitment.api.dto.request.JobPostingUpdateDTO;
+import com.fallguys.recruitment.api.dto.response.FreelancerJobPostingSearchDTO;
 import com.fallguys.recruitment.api.dto.response.JobPostingSearchDTO;
 
 import java.util.List;
@@ -16,6 +17,16 @@ public interface JobPostingService {
     //TODO:paging
     List<JobPostingSearchDTO> getJobPostings(Long userId);
 
+    List<JobPostingSearchDTO> getAllJobPostings();
 
+    List<FreelancerJobPostingSearchDTO> searchJobPostingsForFreelancer(
+            Long freelancerId,
+            String keyword,
+            boolean favoritesOnly
+    );
+
+    void addFavoriteJobPosting(Long freelancerId, Long jobPostingId);
+
+    void removeFavoriteJobPosting(Long freelancerId, Long jobPostingId);
 
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingService.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingService.java
@@ -3,7 +3,6 @@ package com.fallguys.recruitment.service;
 import com.fallguys.recruitment.api.dto.request.JobPostingCreateDTO;
 import com.fallguys.recruitment.api.dto.request.JobPostingUpdateDTO;
 import com.fallguys.recruitment.api.dto.response.JobPostingSearchDTO;
-import com.fallguys.recruitment.entity.JobPosting;
 
 import java.util.List;
 
@@ -14,7 +13,9 @@ public interface JobPostingService {
 
     void deleteJobPosting(Long jobPostingId,Long userId);
 
+    //TODO:paging
     List<JobPostingSearchDTO> getJobPostings(Long userId);
+
 
 
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingService.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingService.java
@@ -2,6 +2,10 @@ package com.fallguys.recruitment.service;
 
 import com.fallguys.recruitment.api.dto.request.JobPostingCreateDTO;
 import com.fallguys.recruitment.api.dto.request.JobPostingUpdateDTO;
+import com.fallguys.recruitment.api.dto.response.JobPostingSearchDTO;
+import com.fallguys.recruitment.entity.JobPosting;
+
+import java.util.List;
 
 public interface JobPostingService {
     void createJobPosting(JobPostingCreateDTO jobPostingCreateDTO, Long userId);
@@ -9,5 +13,8 @@ public interface JobPostingService {
     void updateJobPosting(JobPostingUpdateDTO jobPostingUpdateDTO, Long jobPostingId,Long userId);
 
     void deleteJobPosting(Long jobPostingId,Long userId);
+
+    List<JobPostingSearchDTO> getJobPostings(Long userId);
+
 
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
@@ -4,6 +4,7 @@ import com.fallguys.common.exception.BusinessException;
 import com.fallguys.common.exception.ErrorCode;
 import com.fallguys.recruitment.api.dto.request.JobPostingCreateDTO;
 import com.fallguys.recruitment.api.dto.request.JobPostingUpdateDTO;
+import com.fallguys.recruitment.api.dto.response.JobPostingSearchDTO;
 import com.fallguys.recruitment.entity.JobPosting;
 import com.fallguys.recruitment.entity.Status;
 import com.fallguys.recruitment.repository.JobPostingRepo;
@@ -14,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -21,6 +24,16 @@ public class JobPostingServiceImpl implements JobPostingService {
 
     private final JobPostingRepo jobPostingRepo;
     private final UserRepository userRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<JobPostingSearchDTO> getJobPostings(Long userId) {
+
+        User user = getEmployerOrThrow(userId);
+
+        return jobPostingRepo
+                .findAllByEmployerIdAndDeletedFalse(user.getId());
+    }
 
     @Override
     @Transactional

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
@@ -4,9 +4,13 @@ import com.fallguys.common.exception.BusinessException;
 import com.fallguys.common.exception.ErrorCode;
 import com.fallguys.recruitment.api.dto.request.JobPostingCreateDTO;
 import com.fallguys.recruitment.api.dto.request.JobPostingUpdateDTO;
+import com.fallguys.recruitment.api.dto.response.FreelancerJobPostingSearchDTO;
 import com.fallguys.recruitment.api.dto.response.JobPostingSearchDTO;
+import com.fallguys.recruitment.entity.JobPostingFavorite;
 import com.fallguys.recruitment.entity.JobPosting;
+import com.fallguys.recruitment.entity.JobPostingStatus;
 import com.fallguys.recruitment.entity.Status;
+import com.fallguys.recruitment.repository.JobPostingFavoriteRepo;
 import com.fallguys.recruitment.repository.JobPostingRepo;
 import com.fallguys.user.entity.Role;
 import com.fallguys.user.entity.User;
@@ -15,7 +19,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -23,16 +31,17 @@ import java.util.List;
 public class JobPostingServiceImpl implements JobPostingService {
 
     private final JobPostingRepo jobPostingRepo;
+    private final JobPostingFavoriteRepo jobPostingFavoriteRepo;
     private final UserRepository userRepository;
 
     @Override
     @Transactional(readOnly = true)
     public List<JobPostingSearchDTO> getJobPostings(Long userId) {
-
         User user = getEmployerOrThrow(userId);
-
-        return jobPostingRepo
-                .findAllByEmployerIdAndDeletedFalse(user.getId());
+        return jobPostingRepo.findAllByEmployerIdAndStatusNot(user.getId(), Status.DELETED)
+                .stream()
+                .map(this::toJobPostingSearchDto)
+                .toList();
     }
 
     @Override
@@ -63,6 +72,56 @@ public class JobPostingServiceImpl implements JobPostingService {
         jobPosting.delete();
     }
 
+    @Override
+    public List<JobPostingSearchDTO> getAllJobPostings() {
+        return jobPostingRepo.findAllByStatusNot(Status.DELETED)
+                .stream()
+                .map(this::toJobPostingSearchDto)
+                .toList();
+    }
+
+    @Override
+    public List<FreelancerJobPostingSearchDTO> searchJobPostingsForFreelancer(Long freelancerId, String keyword, boolean favoritesOnly) {
+        getFreelancerOrThrow(freelancerId);
+
+        Set<Long> favoriteJobPostingIds = new HashSet<>(
+                jobPostingFavoriteRepo.findAllByFreelancerId(freelancerId)
+                        .stream()
+                        .map(JobPostingFavorite::getJobPostingId)
+                        .toList()
+        );
+
+        String normalizedKeyword = keyword == null ? "" : keyword.trim().toLowerCase(Locale.ROOT);
+
+        return jobPostingRepo.findAllByStatusAndPostingStatus(Status.ACTIVE, JobPostingStatus.OPEN)
+                .stream()
+                .filter(jobPosting -> matchesKeyword(jobPosting, normalizedKeyword))
+                .filter(jobPosting -> !favoritesOnly || favoriteJobPostingIds.contains(jobPosting.getId()))
+                .map(jobPosting -> toFreelancerSearchDto(jobPosting, favoriteJobPostingIds.contains(jobPosting.getId())))
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public void addFavoriteJobPosting(Long freelancerId, Long jobPostingId) {
+        getFreelancerOrThrow(freelancerId);
+
+        JobPosting jobPosting = getJobPostingOrThrow(jobPostingId);
+        validateNotDeleted(jobPosting);
+
+        if (!jobPostingFavoriteRepo.existsByFreelancerIdAndJobPostingId(freelancerId, jobPostingId)) {
+            jobPostingFavoriteRepo.save(JobPostingFavorite.of(freelancerId, jobPostingId));
+        }
+    }
+
+    @Override
+    @Transactional
+    public void removeFavoriteJobPosting(Long freelancerId, Long jobPostingId) {
+        getFreelancerOrThrow(freelancerId);
+
+        jobPostingFavoriteRepo.deleteByFreelancerIdAndJobPostingId(freelancerId, jobPostingId);
+    }
+
     private User getEmployerOrThrow(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
@@ -87,5 +146,55 @@ public class JobPostingServiceImpl implements JobPostingService {
         if (jobPosting.getStatus() == Status.DELETED) {
             throw new BusinessException(ErrorCode.JOB_POSTING_ALREADY_DELETED);
         }
+    }
+
+    private User getFreelancerOrThrow(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        if (user.getRole() != Role.FREELANCER) {
+            throw new BusinessException(ErrorCode.ONLY_FREELANCER_ALLOWED);
+        }
+        return user;
+    }
+
+    private JobPostingSearchDTO toJobPostingSearchDto(JobPosting jobPosting) {
+        return new JobPostingSearchDTO(
+                jobPosting.getTitle(),
+                jobPosting.getDescription(),
+                new ArrayList<>(jobPosting.getTechStack()),
+                jobPosting.getBudget(),
+                jobPosting.getDuration(),
+                jobPosting.getPostingStatus()
+        );
+    }
+
+    private FreelancerJobPostingSearchDTO toFreelancerSearchDto(JobPosting jobPosting, boolean favorite) {
+        return new FreelancerJobPostingSearchDTO(
+                jobPosting.getId(),
+                jobPosting.getEmployerName(),
+                jobPosting.getTitle(),
+                jobPosting.getDescription(),
+                new ArrayList<>(jobPosting.getTechStack()),
+                jobPosting.getBudget(),
+                jobPosting.getDuration(),
+                favorite
+        );
+    }
+
+    private boolean matchesKeyword(JobPosting jobPosting, String keyword) {
+        if (keyword.isBlank()) {
+            return true;
+        }
+
+        if (containsIgnoreCase(jobPosting.getTitle(), keyword) || containsIgnoreCase(jobPosting.getDescription(), keyword)) {
+            return true;
+        }
+
+        return jobPosting.getTechStack().stream()
+                .anyMatch(tech -> containsIgnoreCase(tech, keyword));
+    }
+
+    private boolean containsIgnoreCase(String source, String keyword) {
+        return source != null && source.toLowerCase(Locale.ROOT).contains(keyword);
     }
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
@@ -159,6 +159,8 @@ public class JobPostingServiceImpl implements JobPostingService {
 
     private JobPostingSearchDTO toJobPostingSearchDto(JobPosting jobPosting) {
         return new JobPostingSearchDTO(
+                jobPosting.getId(),
+                jobPosting.getEmployerName(),
                 jobPosting.getTitle(),
                 jobPosting.getDescription(),
                 new ArrayList<>(jobPosting.getTechStack()),

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
@@ -16,6 +16,7 @@ import com.fallguys.user.entity.Role;
 import com.fallguys.user.entity.User;
 import com.fallguys.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -109,8 +110,10 @@ public class JobPostingServiceImpl implements JobPostingService {
         JobPosting jobPosting = getJobPostingOrThrow(jobPostingId);
         validateNotDeleted(jobPosting);
 
-        if (!jobPostingFavoriteRepo.existsByFreelancerIdAndJobPostingId(freelancerId, jobPostingId)) {
+        try {
             jobPostingFavoriteRepo.save(JobPostingFavorite.of(freelancerId, jobPostingId));
+        } catch (DataIntegrityViolationException ignored) {
+            // Duplicate favorite is treated as idempotent no-op.
         }
     }
 


### PR DESCRIPTION
## 🔗 Related Issue
> 이슈 번호를 작성해주세요. (예: Closes #123)
- Closes #`[이슈번호기입]`

## 📝 작업 내용
프리랜서 관점 공고 검색 기능을 추가하고, 작성한 API 명세(`api/v1/...`)에 맞춰 고용주/프리랜서 공고 API를 정렬했습니다.  
또한 `@RequestMapping` 없이 메서드별 경로 매핑으로 변경했습니다.

## ✅ Changes
> 주요 변경 사항을 bullet point로 정리합니다.
- 프리랜서 공고 검색 API 추가
  - `GET /api/v1/freelancer/jobs?freelancerId=&keyword=&liked=&page=&size=`
- 프리랜서 공고 좋아요(즐겨찾기) API 추가
  - `POST /api/v1/freelancer/jobs/{jobPostingId}/like`
  - `DELETE /api/v1/freelancer/jobs/{jobPostingId}/like`
- 고용주 공고 API 추가/정렬
  - `GET /api/v1/employer/jobs/`
  - `POST /api/v1/employer/jobs/post`
  - `PUT /api/v1/employer/jobs/put?jobsNumber=`
  - `DELETE /api/v1/employer/jobs/del?jobsNumber=`
- 공고 조회 응답/페이징 DTO 추가
  - `PagedResponseDTO` 도입
  - `JobPostingSearchDTO`에 `jobPostingId`, `employerName` 포함
- 서비스 로직 보강
  - 프리랜서 권한 검증 및 검색(키워드/liked 필터) 처리
  - 즐겨찾기 추가/삭제 처리
- `@RequestMapping` 제거
  - 컨트롤러 클래스 레벨 매핑 제거 후 메서드별 절대 경로로 변경
- 컴파일 검증
  - `:recruitment:compileJava` 통과

## 📸 스크린샷 (선택)
> UI 변경 사항이나 테스트 결과 화면이 있다면 첨부해주세요.
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
> 리뷰 시 유의할 점, 후속 PR 예정 사항, 배포 영향 등을 적습니다.
- 현재 페이징은 서비스 결과 리스트 기준 메모리 페이징입니다. 대용량 데이터 대응을 위해 추후 Repository 레벨(Pageable) 페이징으로 전환이 필요합니다.
- 프로젝트 조회 API(`GET /api/v1/employer/project`)는 이번 PR 범위에 포함하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채용담당자는 직무 공고를 생성·조회·수정·삭제할 수 있습니다.
  * 프리랜서는 키워드 검색, 좋아요(즐겨찾기) 필터로 직무 공고를 찾을 수 있습니다.
  * 프리랜서는 공고를 즐겨찾기에 추가/제거할 수 있습니다.
  * 목록 조회에 대한 페이지네이션(페이징) 지원이 추가되었습니다.

* **버그 수정**
  * 프리랜서 전용 기능에 대한 오류 처리 및 권한 관련 응답 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->