### PR TITLE
HFP 74 feat job posting service

### DIFF
--- a/freebridge/recruitment/build.gradle
+++ b/freebridge/recruitment/build.gradle
@@ -9,4 +9,5 @@ dependencies {
     implementation project(':user')
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    compileOnly 'org.springdoc:springdoc-openapi-starter-webmvc-ui'
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/JobPostingEmployerController.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/JobPostingEmployerController.java
@@ -7,6 +7,8 @@ import com.fallguys.recruitment.api.dto.response.JobPostingSearchDTO;
 import com.fallguys.recruitment.api.dto.response.PagedResponseDTO;
 import com.fallguys.recruitment.api.util.PagingUtils;
 import com.fallguys.recruitment.service.JobPostingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -21,10 +23,12 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Recruitment - Employer", description = "고용주 채용 공고 관리 API")
 public class JobPostingEmployerController {
 
     private final JobPostingService jobPostingService;
 
+    @Operation(summary = "내 채용 공고 목록 조회", description = "고용주가 등록한 채용 공고 목록을 조회합니다.")
     @GetMapping("/api/v1/employer/jobs")
     public ResponseEntity<ApiResponse<PagedResponseDTO<JobPostingSearchDTO>>> getMyJobPostings(
             @RequestParam Long employerId,
@@ -35,6 +39,7 @@ public class JobPostingEmployerController {
         return ResponseEntity.ok(ApiResponse.ok(PagingUtils.toPagedResponse(result, page, size)));
     }
 
+    @Operation(summary = "채용 공고 등록", description = "새로운 채용 공고를 등록합니다.")
     @PostMapping("/api/v1/employer/jobs/post")
     public ResponseEntity<ApiResponse<Void>> createJobPosting(
             @RequestParam Long employerId,
@@ -44,6 +49,7 @@ public class JobPostingEmployerController {
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
+    @Operation(summary = "채용 공고 수정", description = "기존 채용 공고 내용을 수정합니다.")
     @PutMapping("/api/v1/employer/jobs/put")
     public ResponseEntity<ApiResponse<Void>> updateJobPosting(
             @RequestParam(name = "jobsNumber") Long jobsNumber,
@@ -54,6 +60,7 @@ public class JobPostingEmployerController {
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
+    @Operation(summary = "채용 공고 삭제", description = "등록된 채용 공고를 삭제합니다.")
     @DeleteMapping("/api/v1/employer/jobs/del")
     public ResponseEntity<ApiResponse<Void>> deleteJobPosting(
             @RequestParam(name = "jobsNumber") Long jobsNumber,

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/JobPostingFreelancerController.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/JobPostingFreelancerController.java
@@ -5,6 +5,8 @@ import com.fallguys.recruitment.api.dto.response.FreelancerJobPostingSearchDTO;
 import com.fallguys.recruitment.api.dto.response.PagedResponseDTO;
 import com.fallguys.recruitment.api.util.PagingUtils;
 import com.fallguys.recruitment.service.JobPostingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -18,10 +20,12 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Recruitment - Freelancer", description = "프리랜서 채용 공고 조회 및 관심 공고 관리 API")
 public class JobPostingFreelancerController {
 
     private final JobPostingService jobPostingService;
 
+    @Operation(summary = "채용 공고 검색", description = "프리랜서가 조건에 맞는 채용 공고를 조회합니다.")
     @GetMapping("/api/v1/freelancer/jobs")
     public ResponseEntity<ApiResponse<PagedResponseDTO<FreelancerJobPostingSearchDTO>>> searchJobPostings(
             @RequestParam Long freelancerId,
@@ -37,6 +41,7 @@ public class JobPostingFreelancerController {
         return ResponseEntity.ok(ApiResponse.ok(paged));
     }
 
+    @Operation(summary = "관심 공고 등록", description = "채용 공고를 관심 목록에 추가합니다.")
     @PostMapping("/api/v1/freelancer/jobs/{jobPostingId}/like")
     public ResponseEntity<ApiResponse<Void>> addFavorite(
             @RequestParam Long freelancerId,
@@ -46,6 +51,7 @@ public class JobPostingFreelancerController {
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
+    @Operation(summary = "관심 공고 해제", description = "관심 목록에서 채용 공고를 제거합니다.")
     @DeleteMapping("/api/v1/freelancer/jobs/{jobPostingId}/like")
     public ResponseEntity<ApiResponse<Void>> removeFavorite(
             @RequestParam Long freelancerId,

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/config/RecruitmentSwaggerConfig.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/config/RecruitmentSwaggerConfig.java
@@ -1,0 +1,20 @@
+package com.fallguys.recruitment.config;
+
+import com.fallguys.common.config.SwaggerConfigInterface;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RecruitmentSwaggerConfig implements SwaggerConfigInterface {
+
+    @Bean
+    public GroupedOpenApi recruitmentGroupedOpenApi() {
+        return createGroupedOpenApi(
+                "recruitment", // 파라미터 1: group (Swagger 상단 Select 박스에 표시될 이름)
+                "/api/v1/recruitment/**", // 파라미터 2: pathsToMatch (스캔할 컨트롤러들의 URL 패턴. 배열로 다중 입력 가능)
+                "Recruitment API", // 파라미터 3: title (API 명세서 메인 제목)
+                "채용 공고 등록 및 조회 도메인 API" // 파라미터 4: description (API 명세서 상세 설명)
+        );
+    }
+}

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/config/RecruitmentSwaggerConfig.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/config/RecruitmentSwaggerConfig.java
@@ -1,6 +1,7 @@
 package com.fallguys.recruitment.config;
 
 import com.fallguys.common.config.SwaggerConfigInterface;
+import io.swagger.v3.oas.models.info.Info;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,11 +11,19 @@ public class RecruitmentSwaggerConfig implements SwaggerConfigInterface {
 
     @Bean
     public GroupedOpenApi recruitmentGroupedOpenApi() {
-        return createGroupedOpenApi(
-                "recruitment", // 파라미터 1: group (Swagger 상단 Select 박스에 표시될 이름)
-                "/api/v1/recruitment/**", // 파라미터 2: pathsToMatch (스캔할 컨트롤러들의 URL 패턴. 배열로 다중 입력 가능)
-                "Recruitment API", // 파라미터 3: title (API 명세서 메인 제목)
-                "채용 공고 등록 및 조회 도메인 API" // 파라미터 4: description (API 명세서 상세 설명)
-        );
+        return GroupedOpenApi.builder()
+                .group("recruitment")
+                .pathsToMatch(
+                        "/api/v1/employer/**",
+                        "/api/v1/freelancer/**"
+                )
+                .addOpenApiCustomizer(openApi ->
+                        openApi.setInfo(new Info()
+                                .title("Recruitment API")
+                                .description("채용 공고 등록 및 조회 도메인 API")
+                                .version("1.0.0")
+                        )
+                )
+                .build();
     }
 }


### PR DESCRIPTION
🔗 Related Issue
Closes #이슈번호
📝 작업 내용
Recruitment 도메인의 Swagger 문서화를 보강하고, 실제 컨트롤러 경로와 Swagger 스캔 경로를 일치시켰습니다.

✅ Changes
JobPostingEmployerController에 Swagger 어노테이션 추가
클래스: @Tag
메서드: @Operation(summary, description)
JobPostingFreelancerController에 Swagger 어노테이션 추가
클래스: @Tag
메서드: @Operation(summary, description)
RecruitmentSwaggerConfig 수정
pathsToMatch를 실제 API 경로에 맞게 변경
/api/v1/employer/**
/api/v1/freelancer/**
📸 스크린샷 (선택)
Swagger UI에서 recruitment 그룹에 Employer/Freelancer 채용 API가 노출되는 화면 첨부 권장.

⚠️ Notes (Optional)
기능 로직 변경은 없고 문서화/설정 변경만 포함됩니다.
기존 /api/v1/recruitment/** 기준 스캔 누락 문제를 경로 정합성으로 해결했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * API 문서화 인프라 개선: Swagger/OpenAPI 지원 추가로 채용 공고 관리 및 조회 API의 자동 문서화 및 대화형 UI 제공
  * 고용주 및 프리랜서 API 엔드포인트에 상세 설명 추가로 API 사용 편의성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->