### PR TITLE
HFP-98 BE User Like

### DIFF
--- a/freebridge/common/src/main/java/com/fallguys/common/security/SecurityConfig.java
+++ b/freebridge/common/src/main/java/com/fallguys/common/security/SecurityConfig.java
@@ -25,8 +25,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 사용하지
                                                                                                               // 않음
                 .authorizeHttpRequests(auth -> auth
-                        // 일단 모든 API 요청을 인증 없이도 통과시킵니다. (테스트 목적)
-                        // Filter는 동작하여 토큰이 있으면 유효성 검사 및 SecurityContext에 세팅은 해줌
+                        .requestMatchers("/api/v1/employer/**").hasRole("EMPLOYER")
                         .anyRequest().permitAll())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/freebridge/user/build.gradle
+++ b/freebridge/user/build.gradle
@@ -13,5 +13,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.security:spring-security-crypto'
     compileOnly 'org.springdoc:springdoc-openapi-starter-webmvc-ui'
+    compileOnly 'io.jsonwebtoken:jjwt-api:0.13.0'
     compileOnly 'org.springframework.security:spring-security-core'
 }

--- a/freebridge/user/src/main/java/com/fallguys/userlike/api/support/UserLikeTokenUserIdResolver.java
+++ b/freebridge/user/src/main/java/com/fallguys/userlike/api/support/UserLikeTokenUserIdResolver.java
@@ -1,0 +1,34 @@
+package com.fallguys.userlike.api.support;
+
+import com.fallguys.common.exception.BusinessException;
+import com.fallguys.common.exception.ErrorCode;
+import com.fallguys.common.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component("userLikeTokenUserIdResolver")
+@RequiredArgsConstructor
+public class UserLikeTokenUserIdResolver {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public Long resolveUserId(String authorizationHeader) {
+        if (!StringUtils.hasText(authorizationHeader) || !authorizationHeader.startsWith(BEARER_PREFIX)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        String token = authorizationHeader.substring(BEARER_PREFIX.length());
+        if (!jwtTokenProvider.validateToken(token)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        Number userIdValue = jwtTokenProvider.getClaimsFromToken(token).get("id", Number.class);
+        if (userIdValue == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        return userIdValue.longValue();
+    }
+}

--- a/freebridge/user/src/main/java/com/fallguys/userlike/api/web/EmployerFreelancerFavoriteController.java
+++ b/freebridge/user/src/main/java/com/fallguys/userlike/api/web/EmployerFreelancerFavoriteController.java
@@ -1,0 +1,45 @@
+package com.fallguys.userlike.api.web;
+
+import com.fallguys.common.response.ApiResponse;
+import com.fallguys.userlike.api.support.UserLikeTokenUserIdResolver;
+import com.fallguys.userlike.service.EmployerFreelancerFavoriteService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Employer MyPage - Favorite", description = "고용주 즐겨찾기(프리랜서) 관리 API")
+@RestController
+@RequiredArgsConstructor
+public class EmployerFreelancerFavoriteController {
+
+    private final EmployerFreelancerFavoriteService favoriteService;
+    private final UserLikeTokenUserIdResolver tokenUserIdResolver;
+
+    @Operation(summary = "프리랜서 즐겨찾기 등록", description = "고용주가 프리랜서를 즐겨찾기에 등록합니다.")
+    @PostMapping("/api/v1/employer/freelancers/{freelancerId}/like")
+    public ResponseEntity<ApiResponse<Void>> addFavorite(
+            @RequestHeader("Authorization") String authorization,
+            @PathVariable Long freelancerId
+    ) {
+        Long employerId = tokenUserIdResolver.resolveUserId(authorization);
+        favoriteService.addFavorite(employerId, freelancerId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @Operation(summary = "프리랜서 즐겨찾기 삭제", description = "고용주가 프리랜서 즐겨찾기를 해제합니다.")
+    @DeleteMapping("/api/v1/employer/freelancers/{freelancerId}/like")
+    public ResponseEntity<ApiResponse<Void>> removeFavorite(
+            @RequestHeader("Authorization") String authorization,
+            @PathVariable Long freelancerId
+    ) {
+        Long employerId = tokenUserIdResolver.resolveUserId(authorization);
+        favoriteService.removeFavorite(employerId, freelancerId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+}

--- a/freebridge/user/src/main/java/com/fallguys/userlike/entity/EmployerFreelancerFavorite.java
+++ b/freebridge/user/src/main/java/com/fallguys/userlike/entity/EmployerFreelancerFavorite.java
@@ -1,0 +1,53 @@
+package com.fallguys.userlike.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "employer_freelancer_favorite",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_employer_favorite_employer_freelancer",
+                columnNames = {"employer_id", "freelancer_id"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmployerFreelancerFavorite {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "employer_id", nullable = false)
+    private Long employerId;
+
+    @Column(name = "freelancer_id", nullable = false)
+    private Long freelancerId;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static EmployerFreelancerFavorite of(Long employerId, Long freelancerId) {
+        EmployerFreelancerFavorite favorite = new EmployerFreelancerFavorite();
+        favorite.employerId = employerId;
+        favorite.freelancerId = freelancerId;
+        return favorite;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/freebridge/user/src/main/java/com/fallguys/userlike/repository/EmployerFreelancerFavoriteRepository.java
+++ b/freebridge/user/src/main/java/com/fallguys/userlike/repository/EmployerFreelancerFavoriteRepository.java
@@ -1,0 +1,20 @@
+package com.fallguys.userlike.repository;
+
+import com.fallguys.userlike.entity.EmployerFreelancerFavorite;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface EmployerFreelancerFavoriteRepository extends JpaRepository<EmployerFreelancerFavorite, Long> {
+
+    boolean existsByEmployerIdAndFreelancerId(Long employerId, Long freelancerId);
+
+    Optional<EmployerFreelancerFavorite> findByEmployerIdAndFreelancerId(Long employerId, Long freelancerId);
+
+    List<EmployerFreelancerFavorite> findAllByEmployerIdOrderByCreatedAtDesc(Long employerId);
+
+    void deleteByEmployerIdAndFreelancerId(Long employerId, Long freelancerId);
+}

--- a/freebridge/user/src/main/java/com/fallguys/userlike/repository/EmployerFreelancerFavoriteRepository.java
+++ b/freebridge/user/src/main/java/com/fallguys/userlike/repository/EmployerFreelancerFavoriteRepository.java
@@ -10,11 +10,5 @@ import java.util.Optional;
 @Repository
 public interface EmployerFreelancerFavoriteRepository extends JpaRepository<EmployerFreelancerFavorite, Long> {
 
-    boolean existsByEmployerIdAndFreelancerId(Long employerId, Long freelancerId);
-
-    Optional<EmployerFreelancerFavorite> findByEmployerIdAndFreelancerId(Long employerId, Long freelancerId);
-
-    List<EmployerFreelancerFavorite> findAllByEmployerIdOrderByCreatedAtDesc(Long employerId);
-
     void deleteByEmployerIdAndFreelancerId(Long employerId, Long freelancerId);
 }

--- a/freebridge/user/src/main/java/com/fallguys/userlike/service/EmployerFreelancerFavoriteService.java
+++ b/freebridge/user/src/main/java/com/fallguys/userlike/service/EmployerFreelancerFavoriteService.java
@@ -1,0 +1,8 @@
+package com.fallguys.userlike.service;
+
+public interface EmployerFreelancerFavoriteService {
+
+    void addFavorite(Long employerId, Long freelancerId);
+
+    void removeFavorite(Long employerId, Long freelancerId);
+}

--- a/freebridge/user/src/main/java/com/fallguys/userlike/service/EmployerFreelancerFavoriteServiceImpl.java
+++ b/freebridge/user/src/main/java/com/fallguys/userlike/service/EmployerFreelancerFavoriteServiceImpl.java
@@ -1,0 +1,32 @@
+package com.fallguys.userlike.service;
+
+import com.fallguys.userlike.entity.EmployerFreelancerFavorite;
+import com.fallguys.userlike.repository.EmployerFreelancerFavoriteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EmployerFreelancerFavoriteServiceImpl implements EmployerFreelancerFavoriteService {
+
+    private final EmployerFreelancerFavoriteRepository favoriteRepository;
+
+    @Override
+    @Transactional
+    public void addFavorite(Long employerId, Long freelancerId) {
+        try {
+            favoriteRepository.save(EmployerFreelancerFavorite.of(employerId, freelancerId));
+        } catch (DataIntegrityViolationException ignored) {
+            // Duplicate favorite is treated as idempotent no-op.
+        }
+    }
+
+    @Override
+    @Transactional
+    public void removeFavorite(Long employerId, Long freelancerId) {
+        favoriteRepository.deleteByEmployerIdAndFreelancerId(employerId, freelancerId);
+    }
+}

--- a/freebridge/user/src/main/java/com/fallguys/userlike/service/EmployerFreelancerFavoriteServiceImpl.java
+++ b/freebridge/user/src/main/java/com/fallguys/userlike/service/EmployerFreelancerFavoriteServiceImpl.java
@@ -7,6 +7,9 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.SQLException;
+import java.util.Locale;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -19,7 +22,10 @@ public class EmployerFreelancerFavoriteServiceImpl implements EmployerFreelancer
     public void addFavorite(Long employerId, Long freelancerId) {
         try {
             favoriteRepository.save(EmployerFreelancerFavorite.of(employerId, freelancerId));
-        } catch (DataIntegrityViolationException ignored) {
+        } catch (DataIntegrityViolationException ex) {
+            if (!isDuplicateKeyViolation(ex)) {
+                throw ex;
+            }
             // Duplicate favorite is treated as idempotent no-op.
         }
     }
@@ -28,5 +34,28 @@ public class EmployerFreelancerFavoriteServiceImpl implements EmployerFreelancer
     @Transactional
     public void removeFavorite(Long employerId, Long freelancerId) {
         favoriteRepository.deleteByEmployerIdAndFreelancerId(employerId, freelancerId);
+    }
+
+    private boolean isDuplicateKeyViolation(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof SQLException sqlException) {
+                String sqlState = sqlException.getSQLState();
+                if ("23505".equals(sqlState)) {
+                    return true;
+                }
+                if (sqlException.getErrorCode() == 1062) {
+                    return true;
+                }
+            }
+
+            String message = current.getMessage();
+            if (message != null && message.toLowerCase(Locale.ROOT).contains("duplicate")) {
+                return true;
+            }
+
+            current = current.getCause();
+        }
+        return false;
     }
 }

--- a/freebridge/user/src/main/java/com/fallguys/userlike/service/EmployerFreelancerFavoriteServiceImpl.java
+++ b/freebridge/user/src/main/java/com/fallguys/userlike/service/EmployerFreelancerFavoriteServiceImpl.java
@@ -35,7 +35,7 @@ public class EmployerFreelancerFavoriteServiceImpl implements EmployerFreelancer
     public void removeFavorite(Long employerId, Long freelancerId) {
         favoriteRepository.deleteByEmployerIdAndFreelancerId(employerId, freelancerId);
     }
-
+    //중복 입력 조절
     private boolean isDuplicateKeyViolation(Throwable throwable) {
         Throwable current = throwable;
         while (current != null) {


### PR DESCRIPTION
🔗 Related Issue
이슈 번호를 작성해주세요. (예: Closes #123)

Closes # (이슈 번호 입력 필요)
📝 작업 내용
userlike 도메인에 고용주-프리랜서 즐겨찾기 기능을 추가했습니다.
프론트에서 버튼 하나로 토글할 수 있도록 등록/삭제 API 2개만 제공하도록 구성했습니다.

✅ Changes
EmployerFreelancerFavorite 엔티티 추가
EmployerFreelancerFavoriteRepository 추가
즐겨찾기 등록/삭제 서비스 추가
중복 등록은 idempotent no-op 처리
삭제는 존재하지 않아도 no-op 처리
EmployerFreelancerFavoriteController 추가
POST /api/v1/employer/freelancers/{freelancerId}/like
DELETE /api/v1/employer/freelancers/{freelancerId}/like
Authorization: Bearer {JWT} 기반 사용자 식별 resolver 추가
UserLikeTokenUserIdResolver
user 모듈 컴파일을 위해 jjwt-api compileOnly 의존성 추가
:user:compileJava 빌드 검증 완료
📸 스크린샷 (선택)
UI 변경 사항이나 테스트 결과 화면이 있다면 첨부해주세요.

<img width="500" alt="스크린샷" src="">
⚠️ Notes (Optional)
현재 API는 JobPosting_Like와 동일한 사용 패턴(등록/삭제 분리)으로 설계했습니다.
프론트는 현재 상태값에 따라 POST/DELETE를 분기 호출하면 됩니다.
이번 PR은 즐겨찾기 조회 API(목록/상태 조회)는 포함하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 고용주가 프리랜서를 즐겨찾기에 추가/제거할 수 있는 REST API가 추가되었습니다.
  * Authorization 헤더의 Bearer 토큰에서 사용자 ID를 추출해 좋아요 동작을 수행합니다.
* **수정**
  * 동일한 즐겨찾기 중복 저장 시 예외를 무시하도록 처리해 중복 오류가 사용자에게 노출되지 않도록 개선했습니다.
* **보안**
  * /api/v1/employer/** 경로에 EMPLOYER 역할 기반 접근 제어가 적용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->