### PR TITLE
HFP 74 feat job posting service

### DIFF
--- a/freebridge/common/src/main/java/com/fallguys/common/security/JwtAuthenticationFilter.java
+++ b/freebridge/common/src/main/java/com/fallguys/common/security/JwtAuthenticationFilter.java
@@ -33,8 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
                 var claims = jwtTokenProvider.getClaimsFromToken(jwt);
-                String userIdStr = claims.getSubject();
-                Long userId = userIdStr != null ? Long.parseLong(userIdStr) : null;
+                Long userId = resolveUserId(claims);
                 String email = claims.get("email", String.class);
                 String role = claims.get("role", String.class);
 
@@ -71,6 +70,30 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String bearerToken = request.getHeader("Authorization");
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    private Long resolveUserId(io.jsonwebtoken.Claims claims) {
+        String subject = claims.getSubject();
+        if (StringUtils.hasText(subject)) {
+            try {
+                return Long.parseLong(subject);
+            } catch (NumberFormatException ignored) {
+                // fallback for legacy token format
+            }
+        }
+
+        Object idClaim = claims.get("id");
+        if (idClaim instanceof Number number) {
+            return number.longValue();
+        }
+        if (idClaim instanceof String str && StringUtils.hasText(str)) {
+            try {
+                return Long.parseLong(str);
+            } catch (NumberFormatException ignored) {
+                // handled below
+            }
         }
         return null;
     }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/support/TokenUserIdResolver.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/support/TokenUserIdResolver.java
@@ -25,14 +25,29 @@ public class TokenUserIdResolver {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
-        String subject = jwtTokenProvider.getClaimsFromToken(token).getSubject();
-        if (!StringUtils.hasText(subject)) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        var claims = jwtTokenProvider.getClaimsFromToken(token);
+
+        String subject = claims.getSubject();
+        if (StringUtils.hasText(subject)) {
+            try {
+                return Long.parseLong(subject);
+            } catch (NumberFormatException ignored) {
+                // fallback to legacy id claim
+            }
         }
-        try {
-            return Long.parseLong(subject);
-        } catch (NumberFormatException ex) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+
+        Object idClaim = claims.get("id");
+        if (idClaim instanceof Number number) {
+            return number.longValue();
         }
+        if (idClaim instanceof String str && StringUtils.hasText(str)) {
+            try {
+                return Long.parseLong(str);
+            } catch (NumberFormatException ignored) {
+                // handled below
+            }
+        }
+
+        throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
     }
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/support/TokenUserIdResolver.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/support/TokenUserIdResolver.java
@@ -25,10 +25,14 @@ public class TokenUserIdResolver {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
-        Number userIdValue = jwtTokenProvider.getClaimsFromToken(token).get("id", Number.class);
-        if (userIdValue == null) {
+        String subject = jwtTokenProvider.getClaimsFromToken(token).getSubject();
+        if (!StringUtils.hasText(subject)) {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
-        return userIdValue.longValue();
+        try {
+            return Long.parseLong(subject);
+        } catch (NumberFormatException ex) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
     }
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/entity/JobPosting.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/entity/JobPosting.java
@@ -44,7 +44,7 @@ public class JobPosting extends BaseEntity {
     private Integer matchedHeadcount = 0;
 
     @Convert(converter = StatusConverter.class)
-    @Column(nullable=false)
+    @Column(nullable=false, length = 20, columnDefinition = "varchar(20)")
     private Status status=Status.ACTIVE;
 
     @Enumerated(EnumType.STRING)

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/entity/JobPosting.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/entity/JobPosting.java
@@ -43,7 +43,7 @@ public class JobPosting extends BaseEntity {
     @Column(name = "matched_headcount", nullable = false)
     private Integer matchedHeadcount = 0;
 
-    @Enumerated(EnumType.STRING)
+    @Convert(converter = StatusConverter.class)
     @Column(nullable=false)
     private Status status=Status.ACTIVE;
 

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/entity/StatusConverter.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/entity/StatusConverter.java
@@ -11,10 +11,7 @@ public class StatusConverter implements AttributeConverter<Status, String> {
         if (attribute == null) {
             return null;
         }
-        return switch (attribute) {
-            case ACTIVE -> "OPEN";
-            case DELETED -> "CLOSED";
-        };
+        return attribute.name();
     }
 
     @Override
@@ -23,6 +20,8 @@ public class StatusConverter implements AttributeConverter<Status, String> {
             return null;
         }
         return switch (dbData) {
+            case "ACTIVE" -> Status.ACTIVE;
+            case "DELETED" -> Status.DELETED;
             case "CLOSED" -> Status.DELETED;
             case "OPEN", "IN_PROGRESS", "COMPLETED" -> Status.ACTIVE;
             default -> throw new IllegalArgumentException("Unknown status value: " + dbData);

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/entity/StatusConverter.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/entity/StatusConverter.java
@@ -1,0 +1,31 @@
+package com.fallguys.recruitment.entity;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = false)
+public class StatusConverter implements AttributeConverter<Status, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Status attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return switch (attribute) {
+            case ACTIVE -> "OPEN";
+            case DELETED -> "CLOSED";
+        };
+    }
+
+    @Override
+    public Status convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        return switch (dbData) {
+            case "CLOSED" -> Status.DELETED;
+            case "OPEN", "IN_PROGRESS", "COMPLETED" -> Status.ACTIVE;
+            default -> throw new IllegalArgumentException("Unknown status value: " + dbData);
+        };
+    }
+}

--- a/freebridge/user/src/main/java/com/fallguys/userlike/api/support/UserLikeTokenUserIdResolver.java
+++ b/freebridge/user/src/main/java/com/fallguys/userlike/api/support/UserLikeTokenUserIdResolver.java
@@ -25,14 +25,29 @@ public class UserLikeTokenUserIdResolver {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
-        String subject = jwtTokenProvider.getClaimsFromToken(token).getSubject();
-        if (!StringUtils.hasText(subject)) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        var claims = jwtTokenProvider.getClaimsFromToken(token);
+
+        String subject = claims.getSubject();
+        if (StringUtils.hasText(subject)) {
+            try {
+                return Long.parseLong(subject);
+            } catch (NumberFormatException ignored) {
+                // fallback to legacy id claim
+            }
         }
-        try {
-            return Long.parseLong(subject);
-        } catch (NumberFormatException ex) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+
+        Object idClaim = claims.get("id");
+        if (idClaim instanceof Number number) {
+            return number.longValue();
         }
+        if (idClaim instanceof String str && StringUtils.hasText(str)) {
+            try {
+                return Long.parseLong(str);
+            } catch (NumberFormatException ignored) {
+                // handled below
+            }
+        }
+
+        throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
     }
 }

--- a/freebridge/user/src/main/java/com/fallguys/userlike/api/support/UserLikeTokenUserIdResolver.java
+++ b/freebridge/user/src/main/java/com/fallguys/userlike/api/support/UserLikeTokenUserIdResolver.java
@@ -25,10 +25,14 @@ public class UserLikeTokenUserIdResolver {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
-        Number userIdValue = jwtTokenProvider.getClaimsFromToken(token).get("id", Number.class);
-        if (userIdValue == null) {
+        String subject = jwtTokenProvider.getClaimsFromToken(token).getSubject();
+        if (!StringUtils.hasText(subject)) {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
-        return userIdValue.longValue();
+        try {
+            return Long.parseLong(subject);
+        } catch (NumberFormatException ex) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
     }
 }


### PR DESCRIPTION
🔗 Related Issue
이슈 번호를 작성해주세요. (예: Closes #123)

Closes # (이슈 번호 입력 필요)
📝 작업 내용
채용 공고/리뷰/매칭/유저 즐겨찾기 기능 전반의 인증·Swagger·API 스펙 정합성을 맞추고, 토큰 파싱 및 상태값 불일치로 발생하던 런타임 오류를 해결했습니다.
또한 고용주가 프리랜서를 즐겨찾기 등록/삭제할 수 있는 API를 신규 추가했습니다.

✅ Changes
review 모듈

리뷰 엔티티/리포지토리/서비스/컨트롤러/Swagger 구성 추가

컨트롤러 빈 이름 충돌(EmployerReviewController, FreelancerReviewController) 해결

프리랜서 리뷰 조회 API 응답에서 엔티티 직접 노출 제거, 응답 DTO 매핑 적용

recruitment 모듈

GET /api/v1/employer/project(고용주 프로젝트 페이징 조회) 추가

TokenUserIdResolver를 sub 기반 + id claim fallback 파싱으로 개선

job_posting.status를 ACTIVE/DELETED 모델로 정비

StatusConverter 도입하여 구 데이터(OPEN/CLOSED/...) 하위호환 처리

common 모듈

SecurityConfig에 /api/v1/employer/** → hasRole("EMPLOYER") 적용

JwtAuthenticationFilter에서 sub=email 구 토큰도 처리되도록 ID 파싱 하위호환 적용

user 모듈 (userlike)

EmployerFreelancerFavorite 엔티티/리포지토리 추가

등록/삭제 전용 서비스 및 컨트롤러 추가

POST /api/v1/employer/freelancers/{freelancerId}/like
DELETE /api/v1/employer/freelancers/{freelancerId}/like
DataIntegrityViolationException 처리 개선

중복키 위반만 idempotent no-op
그 외 무결성 오류는 재던짐
문서화

JobPosting, Matchs, Review, EmployerFreelancerFavorite API 명세(요청/응답/실패 예시) 정리

📸 스크린샷 (선택)
UI 변경 사항이나 테스트 결과 화면이 있다면 첨부해주세요.

<img width="500" alt="스크린샷" src="">
⚠️ Notes (Optional)
토큰 포맷이 혼재(sub=id / sub=email)되어 있어 하위호환 파싱을 적용했습니다.
job_posting.status는 ACTIVE/DELETED로 정비했으며, 기존 enum 값 데이터는 컨버터에서 호환 처리합니다.
보안 정책 변경으로 /api/v1/employer/** 호출 시 EMPLOYER 권한이 필요합니다.
후속 PR에서 에러코드 세분화(INVALID_INPUT_VALUE 구체화) 및 토큰 포맷 단일화 정리 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 사용자 인증 토큰 처리 강화로 다양한 형식 지원 및 안정성 개선
  * 채용 공고 상태 관리 시스템 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->