### PR TITLE
Hfp 73 feat matches

### DIFF
--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/api/support/TokenUserIdResolver.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/api/support/TokenUserIdResolver.java
@@ -25,10 +25,29 @@ public class TokenUserIdResolver {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
-        Number userIdValue = jwtTokenProvider.getClaimsFromToken(token).get("id", Number.class);
-        if (userIdValue == null) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        var claims = jwtTokenProvider.getClaimsFromToken(token);
+
+        String subject = claims.getSubject();
+        if (StringUtils.hasText(subject)) {
+            try {
+                return Long.parseLong(subject);
+            } catch (NumberFormatException ignored) {
+                // fallback to legacy id claim
+            }
         }
-        return userIdValue.longValue();
+
+        Object idClaim = claims.get("id");
+        if (idClaim instanceof Number number) {
+            return number.longValue();
+        }
+        if (idClaim instanceof String str && StringUtils.hasText(str)) {
+            try {
+                return Long.parseLong(str);
+            } catch (NumberFormatException ignored) {
+                // handled below
+            }
+        }
+
+        throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
     }
 }

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/entity/Application.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/entity/Application.java
@@ -36,6 +36,7 @@ public class Application {
 
     @Column(nullable=false)
     @Builder.Default
+    @Enumerated(EnumType.STRING)
     private MatchsStatus status=MatchsStatus.PENDING;
 
     @Column

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/entity/Proposal.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/entity/Proposal.java
@@ -30,6 +30,7 @@ public class Proposal {
     private String message;
 
     @Column(nullable=false)
+    @Enumerated(EnumType.STRING)
     @Builder.Default
     private MatchsStatus status=MatchsStatus.PENDING;
 

--- a/freebridge/review/src/main/java/com/fallguys/review/api/support/ReviewTokenUserIdResolver.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/api/support/ReviewTokenUserIdResolver.java
@@ -25,10 +25,29 @@ public class ReviewTokenUserIdResolver {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
-        Number userIdValue = jwtTokenProvider.getClaimsFromToken(token).get("id", Number.class);
-        if (userIdValue == null) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        var claims = jwtTokenProvider.getClaimsFromToken(token);
+
+        String subject = claims.getSubject();
+        if (StringUtils.hasText(subject)) {
+            try {
+                return Long.parseLong(subject);
+            } catch (NumberFormatException ignored) {
+                // fallback to legacy id claim
+            }
         }
-        return userIdValue.longValue();
+
+        Object idClaim = claims.get("id");
+        if (idClaim instanceof Number number) {
+            return number.longValue();
+        }
+        if (idClaim instanceof String str && StringUtils.hasText(str)) {
+            try {
+                return Long.parseLong(str);
+            } catch (NumberFormatException ignored) {
+                // handled below
+            }
+        }
+
+        throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
     }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #<이슈번호>

## 📝 작업 내용
`/api/v1/employer/proposals` 요청 시 `C001(잘못된 입력값)`이 발생하던 문제를 수정했습니다.  
원인은 JWT에서 사용자 ID를 읽는 로직이 `id` claim만 기대하고 있었기 때문이며, 현재 발급 토큰의 `subject` 기반 파싱을 지원하도록 보완했습니다.

## ✅ Changes
- `matchs` 모듈 `TokenUserIdResolver` 수정
- `review` 모듈 `ReviewTokenUserIdResolver` 수정
- 사용자 ID 추출 로직 개선
  - `subject` 우선 파싱
  - 실패 시 legacy `id` claim fallback
  - 둘 다 없을 때만 `INVALID_INPUT_VALUE(C001)` 예외 반환
- `:matchs:compileJava`, `:review:compileJava` 빌드 검증 완료

## 📸 스크린샷 (선택)
- API 재호출 시 기존 `400/C001` 재현되지 않음 (필요 시 Postman 결과 첨부)

## ⚠️ Notes (Optional)
- 도메인 정책은 기존대로 유지: `Project`는 제안/지원 **수락 시에만** 생성
- 거절은 `application/proposal` 상태 이력으로 관리하는 방향이 적절함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 토큰 파싱 로직 개선 - 더 강화된 폴백 메커니즘으로 사용자 ID 추출 안정성 향상
  * 유효하지 않은 토큰 처리 시 일관된 오류 반환

* **개선사항**
  * 데이터베이스에 상태 정보가 더욱 읽기 쉬운 형식으로 저장되도록 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->