### PR TITLE
Hfp 98 be user like

### DIFF
--- a/freebridge/recruitment/src/test/java/com/fallguys/recruitment/api/web/JobPostingFavoriteControllerTest.java
+++ b/freebridge/recruitment/src/test/java/com/fallguys/recruitment/api/web/JobPostingFavoriteControllerTest.java
@@ -1,0 +1,70 @@
+package com.fallguys.recruitment.api.web;
+
+import com.fallguys.common.response.ApiResponse;
+import com.fallguys.recruitment.api.support.TokenUserIdResolver;
+import com.fallguys.recruitment.service.JobPostingService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JobPostingFavoriteControllerTest {
+
+    @Mock
+    private JobPostingService jobPostingService;
+
+    @Mock
+    private TokenUserIdResolver tokenUserIdResolver;
+
+    @InjectMocks
+    private JobPostingFreelancerController controller;
+
+    @Test
+    @DisplayName("[TDD] 관심 공고 등록 API는 토큰 사용자 ID를 해석해 서비스에 전달하고 200을 반환한다")
+    void addFavorite_callsServiceAndReturnsOk() {
+        // given
+        String authorization = "Bearer token";
+        Long jobPostingId = 33L;
+        when(tokenUserIdResolver.resolveUserId(authorization)).thenReturn(7L);
+
+        // when
+        ResponseEntity<ApiResponse<Void>> response = controller.addFavorite(authorization, jobPostingId);
+
+        // then
+        verify(tokenUserIdResolver, times(1)).resolveUserId(authorization);
+        verify(jobPostingService, times(1)).addFavoriteJobPosting(7L, jobPostingId);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(true, response.getBody().success());
+    }
+
+    @Test
+    @DisplayName("[TDD] 관심 공고 해제 API는 토큰 사용자 ID를 해석해 서비스에 전달하고 200을 반환한다")
+    void removeFavorite_callsServiceAndReturnsOk() {
+        // given
+        String authorization = "Bearer token";
+        Long jobPostingId = 44L;
+        when(tokenUserIdResolver.resolveUserId(authorization)).thenReturn(8L);
+
+        // when
+        ResponseEntity<ApiResponse<Void>> response = controller.removeFavorite(authorization, jobPostingId);
+
+        // then
+        verify(tokenUserIdResolver, times(1)).resolveUserId(authorization);
+        verify(jobPostingService, times(1)).removeFavoriteJobPosting(8L, jobPostingId);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(true, response.getBody().success());
+    }
+}

--- a/freebridge/recruitment/src/test/java/com/fallguys/recruitment/service/JobPostingFavoriteServiceTest.java
+++ b/freebridge/recruitment/src/test/java/com/fallguys/recruitment/service/JobPostingFavoriteServiceTest.java
@@ -1,0 +1,183 @@
+package com.fallguys.recruitment.service;
+
+import com.fallguys.common.ai.port.RecommendationEngine;
+import com.fallguys.common.exception.BusinessException;
+import com.fallguys.common.exception.ErrorCode;
+import com.fallguys.recruitment.api.dto.request.JobPostingCreateDTO;
+import com.fallguys.recruitment.api.dto.response.FreelancerJobPostingSearchDTO;
+import com.fallguys.recruitment.entity.JobPosting;
+import com.fallguys.recruitment.entity.JobPostingFavorite;
+import com.fallguys.recruitment.entity.JobPostingStatus;
+import com.fallguys.recruitment.entity.Status;
+import com.fallguys.recruitment.repository.JobPostingFavoriteRepo;
+import com.fallguys.recruitment.repository.JobPostingRepo;
+import com.fallguys.recruitment.repository.ProjectPostingRepo;
+import com.fallguys.recruitment.service.port.RecruitmentUser;
+import com.fallguys.recruitment.service.port.RecruitmentUserReader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JobPostingFavoriteServiceTest {
+
+    @Mock
+    private JobPostingRepo jobPostingRepo;
+
+    @Mock
+    private JobPostingFavoriteRepo jobPostingFavoriteRepo;
+
+    @Mock
+    private ProjectPostingRepo projectPostingRepo;
+
+    @Mock
+    private RecruitmentUserReader recruitmentUserReader;
+
+    @Mock
+    private RecommendationEngine recommendationEngine;
+
+    @InjectMocks
+    private JobPostingServiceImpl jobPostingService;
+
+    @Test
+    @DisplayName("[TDD] 관심 공고 등록 시 freelancer 기준으로 즐겨찾기가 저장된다")
+    void addFavoriteJobPosting_savesFavorite() {
+        // given
+        Long userId = 10L;
+        Long jobPostingId = 101L;
+        when(recruitmentUserReader.getFreelancerByIdOrThrow(userId))
+                .thenReturn(new RecruitmentUser(77L, "freelancer", null, null, "ACTIVE"));
+        when(jobPostingRepo.findById(jobPostingId))
+                .thenReturn(Optional.of(createJobPosting(jobPostingId, "Spring", Status.ACTIVE, JobPostingStatus.OPEN)));
+
+        // when
+        jobPostingService.addFavoriteJobPosting(userId, jobPostingId);
+
+        // then
+        ArgumentCaptor<JobPostingFavorite> captor = ArgumentCaptor.forClass(JobPostingFavorite.class);
+        verify(jobPostingFavoriteRepo, times(1)).save(captor.capture());
+        assertEquals(77L, captor.getValue().getFreelancerId());
+        assertEquals(jobPostingId, captor.getValue().getJobPostingId());
+    }
+
+    @Test
+    @DisplayName("[TDD] 동일 관심 공고 중복 등록 시 예외 없이 no-op 처리된다")
+    void addFavoriteJobPosting_duplicateFavorite_isNoOp() {
+        // given
+        Long userId = 11L;
+        Long jobPostingId = 102L;
+        when(recruitmentUserReader.getFreelancerByIdOrThrow(userId))
+                .thenReturn(new RecruitmentUser(88L, "freelancer", null, null, "ACTIVE"));
+        when(jobPostingRepo.findById(jobPostingId))
+                .thenReturn(Optional.of(createJobPosting(jobPostingId, "Java", Status.ACTIVE, JobPostingStatus.OPEN)));
+        when(jobPostingFavoriteRepo.save(any())).thenThrow(new DataIntegrityViolationException("duplicate"));
+
+        // when & then
+        assertDoesNotThrow(() -> jobPostingService.addFavoriteJobPosting(userId, jobPostingId));
+    }
+
+    @Test
+    @DisplayName("[TDD] 삭제된 공고는 관심 공고 등록 시 JOB_POSTING_ALREADY_DELETED 예외를 던진다")
+    void addFavoriteJobPosting_deletedPosting_throwsBusinessException() {
+        // given
+        Long userId = 12L;
+        Long jobPostingId = 103L;
+        when(recruitmentUserReader.getFreelancerByIdOrThrow(userId))
+                .thenReturn(new RecruitmentUser(99L, "freelancer", null, null, "ACTIVE"));
+        when(jobPostingRepo.findById(jobPostingId))
+                .thenReturn(Optional.of(createJobPosting(jobPostingId, "Kotlin", Status.DELETED, JobPostingStatus.CLOSED)));
+
+        // when
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> jobPostingService.addFavoriteJobPosting(userId, jobPostingId)
+        );
+
+        // then
+        assertEquals(ErrorCode.JOB_POSTING_ALREADY_DELETED, ex.getErrorCode());
+        verify(jobPostingFavoriteRepo, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("[TDD] 관심 공고 해제 시 freelancer 기준 삭제 메서드가 호출된다")
+    void removeFavoriteJobPosting_callsDelete() {
+        // given
+        Long userId = 13L;
+        Long jobPostingId = 104L;
+        when(recruitmentUserReader.getFreelancerByIdOrThrow(userId))
+                .thenReturn(new RecruitmentUser(123L, "freelancer", null, null, "ACTIVE"));
+
+        // when
+        jobPostingService.removeFavoriteJobPosting(userId, jobPostingId);
+
+        // then
+        verify(jobPostingFavoriteRepo, times(1)).deleteByFreelancerIdAndJobPostingId(123L, jobPostingId);
+    }
+
+    @Test
+    @DisplayName("[TDD] favoritesOnly=true 검색 시 관심 공고만 반환되고 favorite 플래그가 true다")
+    void searchJobPostingsForFreelancer_favoritesOnly_filtersAndMarksFavorite() {
+        // given
+        Long userId = 14L;
+        Long freelancerId = 200L;
+        when(recruitmentUserReader.getFreelancerByIdOrThrow(userId))
+                .thenReturn(new RecruitmentUser(freelancerId, "freelancer", null, null, "ACTIVE"));
+
+        JobPosting favoritePosting = createJobPosting(1L, "Spring Backend", Status.ACTIVE, JobPostingStatus.OPEN);
+        JobPosting nonFavoritePosting = createJobPosting(2L, "React Frontend", Status.ACTIVE, JobPostingStatus.IN_PROGRESS);
+
+        when(jobPostingFavoriteRepo.findAllByFreelancerId(freelancerId))
+                .thenReturn(List.of(JobPostingFavorite.of(freelancerId, 1L)));
+        when(jobPostingRepo.findAllByStatusAndPostingStatusIn(
+                org.mockito.ArgumentMatchers.eq(Status.ACTIVE),
+                org.mockito.ArgumentMatchers.<Set<JobPostingStatus>>any()
+        )).thenReturn(List.of(favoritePosting, nonFavoritePosting));
+
+        // when
+        List<FreelancerJobPostingSearchDTO> result =
+                jobPostingService.searchJobPostingsForFreelancer(userId, null, true);
+
+        // then
+        assertEquals(1, result.size());
+        assertEquals(1L, result.get(0).jobPostingId());
+        assertEquals(true, result.get(0).favorite());
+    }
+
+    private JobPosting createJobPosting(Long id, String title, Status status, JobPostingStatus postingStatus) {
+        JobPosting posting = JobPosting.from(
+                new JobPostingCreateDTO(
+                        title,
+                        "desc",
+                        List.of("Java"),
+                        1000L,
+                        3,
+                        1
+                ),
+                1L,
+                "employer"
+        );
+        ReflectionTestUtils.setField(posting, "id", id, Long.class);
+        ReflectionTestUtils.setField(posting, "status", status);
+        ReflectionTestUtils.setField(posting, "postingStatus", postingStatus);
+        return posting;
+    }
+}

--- a/freebridge/user/build.gradle
+++ b/freebridge/user/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     compileOnly 'org.springdoc:springdoc-openapi-starter-webmvc-ui'
     compileOnly 'io.jsonwebtoken:jjwt-api:0.13.0'
     compileOnly 'org.springframework.security:spring-security-core'
+    testImplementation 'io.jsonwebtoken:jjwt-api:0.13.0'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.security:spring-security-core'
 }

--- a/freebridge/user/src/test/java/com/fallguys/userlike/api/support/UserLikeTokenUserIdResolverTest.java
+++ b/freebridge/user/src/test/java/com/fallguys/userlike/api/support/UserLikeTokenUserIdResolverTest.java
@@ -1,0 +1,132 @@
+package com.fallguys.userlike.api.support;
+
+import com.fallguys.common.exception.BusinessException;
+import com.fallguys.common.exception.ErrorCode;
+import com.fallguys.common.security.JwtTokenProvider;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserLikeTokenUserIdResolverTest {
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks
+    private UserLikeTokenUserIdResolver resolver;
+
+    @Mock
+    private Claims claims;
+
+    @Test
+    @DisplayName("[TDD] Authorization 헤더가 비어있으면 INVALID_INPUT_VALUE 예외를 던진다")
+    void resolveUserId_blankHeader_throwsBusinessException() {
+        // when
+        BusinessException exception =
+                assertThrows(BusinessException.class, () -> resolver.resolveUserId(""));
+
+        // then
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, exception.getErrorCode());
+        verify(jwtTokenProvider, never()).validateToken(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    @DisplayName("[TDD] Bearer 형식이 아니면 INVALID_INPUT_VALUE 예외를 던진다")
+    void resolveUserId_invalidBearerPrefix_throwsBusinessException() {
+        // when
+        BusinessException exception =
+                assertThrows(BusinessException.class, () -> resolver.resolveUserId("Token abc"));
+
+        // then
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("[TDD] 토큰 검증 실패 시 INVALID_INPUT_VALUE 예외를 던진다")
+    void resolveUserId_invalidToken_throwsBusinessException() {
+        // given
+        when(jwtTokenProvider.validateToken("bad-token")).thenReturn(false);
+
+        // when
+        BusinessException exception =
+                assertThrows(BusinessException.class, () -> resolver.resolveUserId("Bearer bad-token"));
+
+        // then
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("[TDD] subject가 숫자면 해당 값을 userId로 반환한다")
+    void resolveUserId_numericSubject_returnsUserId() {
+        // given
+        when(jwtTokenProvider.validateToken("valid-token")).thenReturn(true);
+        when(jwtTokenProvider.getClaimsFromToken("valid-token")).thenReturn(claims);
+        when(claims.getSubject()).thenReturn("101");
+
+        // when
+        Long userId = resolver.resolveUserId("Bearer valid-token");
+
+        // then
+        assertEquals(101L, userId);
+    }
+
+    @Test
+    @DisplayName("[TDD] subject가 비숫자면 id(Number) 클레임으로 fallback한다")
+    void resolveUserId_nonNumericSubject_fallbackToNumberIdClaim() {
+        // given
+        when(jwtTokenProvider.validateToken("valid-token")).thenReturn(true);
+        when(jwtTokenProvider.getClaimsFromToken("valid-token")).thenReturn(claims);
+        when(claims.getSubject()).thenReturn("legacy-subject");
+        when(claims.get("id")).thenReturn(202L);
+
+        // when
+        Long userId = resolver.resolveUserId("Bearer valid-token");
+
+        // then
+        assertEquals(202L, userId);
+    }
+
+    @Test
+    @DisplayName("[TDD] subject가 비어있고 id(String) 클레임이 숫자면 파싱해 반환한다")
+    void resolveUserId_blankSubject_parseStringIdClaim() {
+        // given
+        when(jwtTokenProvider.validateToken("valid-token")).thenReturn(true);
+        when(jwtTokenProvider.getClaimsFromToken("valid-token")).thenReturn(claims);
+        when(claims.getSubject()).thenReturn("");
+        when(claims.get("id")).thenReturn("303");
+
+        // when
+        Long userId = resolver.resolveUserId("Bearer valid-token");
+
+        // then
+        assertEquals(303L, userId);
+    }
+
+    @Test
+    @DisplayName("[TDD] subject/id 모두 userId로 해석 불가하면 INVALID_INPUT_VALUE 예외를 던진다")
+    void resolveUserId_unresolvableClaims_throwsBusinessException() {
+        // given
+        when(jwtTokenProvider.validateToken("valid-token")).thenReturn(true);
+        when(jwtTokenProvider.getClaimsFromToken("valid-token")).thenReturn(claims);
+        when(claims.getSubject()).thenReturn("not-number");
+        when(claims.get("id")).thenReturn("NaN");
+
+        // when
+        BusinessException exception =
+                assertThrows(BusinessException.class, () -> resolver.resolveUserId("Bearer valid-token"));
+
+        // then
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, exception.getErrorCode());
+    }
+}

--- a/freebridge/user/src/test/java/com/fallguys/userlike/api/web/EmployerFreelancerFavoriteControllerTest.java
+++ b/freebridge/user/src/test/java/com/fallguys/userlike/api/web/EmployerFreelancerFavoriteControllerTest.java
@@ -1,0 +1,70 @@
+package com.fallguys.userlike.api.web;
+
+import com.fallguys.common.response.ApiResponse;
+import com.fallguys.userlike.api.support.UserLikeTokenUserIdResolver;
+import com.fallguys.userlike.service.EmployerFreelancerFavoriteService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EmployerFreelancerFavoriteControllerTest {
+
+    @Mock
+    private EmployerFreelancerFavoriteService favoriteService;
+
+    @Mock
+    private UserLikeTokenUserIdResolver tokenUserIdResolver;
+
+    @InjectMocks
+    private EmployerFreelancerFavoriteController controller;
+
+    @Test
+    @DisplayName("[TDD] 즐겨찾기 등록 요청 시 userId를 해석해 서비스에 전달하고 200 OK를 반환한다")
+    void addFavorite_callsServiceAndReturnsOk() {
+        // given
+        String authorization = "Bearer token";
+        Long freelancerId = 55L;
+        when(tokenUserIdResolver.resolveUserId(authorization)).thenReturn(11L);
+
+        // when
+        ResponseEntity<ApiResponse<Void>> response = controller.addFavorite(authorization, freelancerId);
+
+        // then
+        verify(tokenUserIdResolver, times(1)).resolveUserId(authorization);
+        verify(favoriteService, times(1)).addFavorite(11L, freelancerId);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(true, response.getBody().success());
+    }
+
+    @Test
+    @DisplayName("[TDD] 즐겨찾기 삭제 요청 시 userId를 해석해 서비스에 전달하고 200 OK를 반환한다")
+    void removeFavorite_callsServiceAndReturnsOk() {
+        // given
+        String authorization = "Bearer token";
+        Long freelancerId = 66L;
+        when(tokenUserIdResolver.resolveUserId(authorization)).thenReturn(22L);
+
+        // when
+        ResponseEntity<ApiResponse<Void>> response = controller.removeFavorite(authorization, freelancerId);
+
+        // then
+        verify(tokenUserIdResolver, times(1)).resolveUserId(authorization);
+        verify(favoriteService, times(1)).removeFavorite(22L, freelancerId);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(true, response.getBody().success());
+    }
+}

--- a/freebridge/user/src/test/java/com/fallguys/userlike/service/EmployerFreelancerFavoriteServiceImplTest.java
+++ b/freebridge/user/src/test/java/com/fallguys/userlike/service/EmployerFreelancerFavoriteServiceImplTest.java
@@ -1,0 +1,103 @@
+package com.fallguys.userlike.service;
+
+import com.fallguys.userlike.repository.EmployerFreelancerFavoriteRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EmployerFreelancerFavoriteServiceImplTest {
+
+    @Mock
+    private EmployerFreelancerFavoriteRepository favoriteRepository;
+
+    @InjectMocks
+    private EmployerFreelancerFavoriteServiceImpl service;
+
+    @Test
+    @DisplayName("[TDD] 즐겨찾기 등록 시 Repository.save를 호출한다")
+    void addFavorite_callsSave() {
+        // given
+        Long employerId = 10L;
+        Long freelancerId = 20L;
+
+        // when
+        service.addFavorite(employerId, freelancerId);
+
+        // then
+        ArgumentCaptor<com.fallguys.userlike.entity.EmployerFreelancerFavorite> captor =
+                ArgumentCaptor.forClass(com.fallguys.userlike.entity.EmployerFreelancerFavorite.class);
+        verify(favoriteRepository, times(1)).save(captor.capture());
+        assertEquals(employerId, captor.getValue().getEmployerId());
+        assertEquals(freelancerId, captor.getValue().getFreelancerId());
+    }
+
+    @Test
+    @DisplayName("[TDD] 즐겨찾기 등록 시 중복 키(SQLState 23505)는 예외 없이 무시한다")
+    void addFavorite_duplicateBySqlState_isNoOp() {
+        // given
+        SQLException sqlException = new SQLException("duplicate key", "23505");
+        DataIntegrityViolationException exception = new DataIntegrityViolationException("duplicate", sqlException);
+        when(favoriteRepository.save(any())).thenThrow(exception);
+
+        // when & then
+        assertDoesNotThrow(() -> service.addFavorite(1L, 2L));
+        verify(favoriteRepository, times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("[TDD] 즐겨찾기 등록 시 중복 키(MySQL 1062)는 예외 없이 무시한다")
+    void addFavorite_duplicateByMysqlErrorCode_isNoOp() {
+        // given
+        SQLException sqlException = new SQLException("Duplicate entry", "23000", 1062);
+        DataIntegrityViolationException exception = new DataIntegrityViolationException("duplicate", sqlException);
+        when(favoriteRepository.save(any())).thenThrow(exception);
+
+        // when & then
+        assertDoesNotThrow(() -> service.addFavorite(1L, 2L));
+    }
+
+    @Test
+    @DisplayName("[TDD] 즐겨찾기 등록 시 비중복 무결성 예외는 그대로 전파한다")
+    void addFavorite_nonDuplicateViolation_throwsException() {
+        // given
+        SQLException sqlException = new SQLException("constraint failure", "22001");
+        DataIntegrityViolationException exception = new DataIntegrityViolationException("constraint violation", sqlException);
+        when(favoriteRepository.save(any())).thenThrow(exception);
+
+        // when & then
+        DataIntegrityViolationException thrown =
+                assertThrows(DataIntegrityViolationException.class, () -> service.addFavorite(1L, 2L));
+        assertEquals("constraint violation", thrown.getMessage());
+    }
+
+    @Test
+    @DisplayName("[TDD] 즐겨찾기 삭제 시 employerId/freelancerId로 삭제 메서드를 호출한다")
+    void removeFavorite_callsDeleteByEmployerIdAndFreelancerId() {
+        // given
+        Long employerId = 7L;
+        Long freelancerId = 9L;
+
+        // when
+        service.removeFavorite(employerId, freelancerId);
+
+        // then
+        verify(favoriteRepository, times(1))
+                .deleteByEmployerIdAndFreelancerId(employerId, freelancerId);
+    }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #미기재

## 📝 작업 내용
`recruitment` 모듈에서 `JobPostingFavorite` 관련 기능만 대상으로 테스트 코드를 추가했습니다.  
서비스 로직(등록/해제/중복/필터링)과 프리랜서 컨트롤러 엔드포인트 흐름을 검증하도록 구성했습니다.

## ✅ Changes
- `JobPostingFavorite` 서비스 테스트 추가
- 관심 공고 등록 시 저장 매핑(`freelancerId`, `jobPostingId`) 검증
- 중복 등록(`DataIntegrityViolationException`) idempotent(no-op) 처리 검증
- 삭제된 공고 즐겨찾기 시 `JOB_POSTING_ALREADY_DELETED` 예외 검증
- 관심 공고 해제 시 `deleteByFreelancerIdAndJobPostingId` 호출 검증
- `favoritesOnly=true` 검색 시 즐겨찾기 공고만 반환되는지 검증
- `JobPostingFreelancerController`의 관심 공고 등록/해제 API 테스트 추가
- 토큰 userId 해석 → 서비스 호출 → `200 OK` 응답 흐름 검증
- 테스트 실행 확인  
  - `:recruitment:test --tests "com.fallguys.recruitment.service.JobPostingFavoriteServiceTest" --tests "com.fallguys.recruitment.api.web.JobPostingFavoriteControllerTest"`  
  - 결과: `BUILD SUCCESSFUL`

## 📸 스크린샷 (선택)
테스트 리포트/콘솔 캡처 첨부 예정

## ⚠️ Notes (Optional)
- 이번 PR은 `JobPostingFavorite` 관련 테스트만 포함하며, 프로덕션 로직 변경은 없습니다.
- 이슈 번호는 확정 후 `Closes #...`로 갱신이 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Tests**
  * 채용공고 및 프리랜서 즐겨찾기 기능에 대한 포괄적인 단위 테스트 추가
  * 토큰 기반 사용자 인증 해석 로직에 대한 테스트 추가
  * API 엔드포인트 동작 검증 테스트 강화

* **Chores**
  * 테스트 환경 의존성 구성 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->