### PR TITLE
HFP-96 [feat] Review Test

### DIFF
--- a/freebridge/review/src/test/java/com/fallguys/review/api/web/EmployerReviewControllerTest.java
+++ b/freebridge/review/src/test/java/com/fallguys/review/api/web/EmployerReviewControllerTest.java
@@ -1,0 +1,87 @@
+package com.fallguys.review.api.web;
+
+import com.fallguys.common.response.ApiResponse;
+import com.fallguys.review.api.dto.request.EmployerReviewCreateRequest;
+import com.fallguys.review.api.support.ReviewTokenUserIdResolver;
+import com.fallguys.review.entity.FreelancerReview;
+import com.fallguys.review.service.ReviewService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EmployerReviewControllerTest {
+
+    @Mock
+    private ReviewService reviewService;
+
+    @Mock
+    private ReviewTokenUserIdResolver reviewTokenUserIdResolver;
+
+    @InjectMocks
+    private EmployerReviewController controller;
+
+    @Test
+    @DisplayName("[TDD] 고용주 리뷰 생성 시 pathVariable projectId를 요청 DTO에 반영해 서비스에 전달한다")
+    void createEmployerReview_mergesProjectIdAndCallsService() {
+        // given
+        String authorization = "Bearer token";
+        Long projectId = 777L;
+        Long employerId = 11L;
+        EmployerReviewCreateRequest request = new EmployerReviewCreateRequest(
+                1L, 22L, 5, 5, 5, 5, 5, 5, "desc"
+        );
+        when(reviewTokenUserIdResolver.resolveUserId(authorization)).thenReturn(employerId);
+        when(reviewService.createEmployerReview(org.mockito.ArgumentMatchers.eq(employerId), org.mockito.ArgumentMatchers.any()))
+                .thenReturn(1000L);
+
+        // when
+        ResponseEntity<ApiResponse<Long>> response = controller.createEmployerReview(authorization, projectId, request);
+
+        // then
+        ArgumentCaptor<EmployerReviewCreateRequest> captor = ArgumentCaptor.forClass(EmployerReviewCreateRequest.class);
+        verify(reviewService, times(1)).createEmployerReview(org.mockito.ArgumentMatchers.eq(employerId), captor.capture());
+        assertEquals(projectId, captor.getValue().projectId());
+        assertEquals(22L, captor.getValue().freelancerId());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(1000L, response.getBody().data());
+    }
+
+    @Test
+    @DisplayName("[TDD] 고용주 수신 리뷰 조회 시 page/size를 안전값으로 보정해 서비스에 전달한다")
+    void getEmployerReceivedReviews_clampsPageAndSize() {
+        // given
+        String authorization = "Bearer token";
+        when(reviewTokenUserIdResolver.resolveUserId(authorization)).thenReturn(1L);
+        Page<FreelancerReview> page = new PageImpl<>(List.of());
+        when(reviewService.getEmployerReceivedReviews(org.mockito.ArgumentMatchers.eq(1L), org.mockito.ArgumentMatchers.any()))
+                .thenReturn(page);
+
+        // when
+        controller.getEmployerReceivedReviews(authorization, -5, 500);
+
+        // then
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(reviewService, times(1)).getEmployerReceivedReviews(org.mockito.ArgumentMatchers.eq(1L), pageableCaptor.capture());
+        assertEquals(0, pageableCaptor.getValue().getPageNumber());
+        assertEquals(100, pageableCaptor.getValue().getPageSize());
+    }
+}

--- a/freebridge/review/src/test/java/com/fallguys/review/api/web/FreelancerReviewControllerTest.java
+++ b/freebridge/review/src/test/java/com/fallguys/review/api/web/FreelancerReviewControllerTest.java
@@ -1,0 +1,87 @@
+package com.fallguys.review.api.web;
+
+import com.fallguys.common.response.ApiResponse;
+import com.fallguys.review.api.dto.request.FreelancerReviewCreateRequest;
+import com.fallguys.review.api.support.ReviewTokenUserIdResolver;
+import com.fallguys.review.entity.EmployerReview;
+import com.fallguys.review.service.ReviewService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FreelancerReviewControllerTest {
+
+    @Mock
+    private ReviewService reviewService;
+
+    @Mock
+    private ReviewTokenUserIdResolver reviewTokenUserIdResolver;
+
+    @InjectMocks
+    private FreelancerReviewController controller;
+
+    @Test
+    @DisplayName("[TDD] 프리랜서 리뷰 생성 시 pathVariable projectId를 요청 DTO에 반영해 서비스에 전달한다")
+    void createFreelancerReview_mergesProjectIdAndCallsService() {
+        // given
+        String authorization = "Bearer token";
+        Long projectId = 501L;
+        Long freelancerId = 31L;
+        FreelancerReviewCreateRequest request = new FreelancerReviewCreateRequest(
+                1L, 41L, 5, 4, 3, "desc"
+        );
+        when(reviewTokenUserIdResolver.resolveUserId(authorization)).thenReturn(freelancerId);
+        when(reviewService.createFreelancerReview(org.mockito.ArgumentMatchers.eq(freelancerId), org.mockito.ArgumentMatchers.any()))
+                .thenReturn(888L);
+
+        // when
+        ResponseEntity<ApiResponse<Long>> response = controller.createFreelancerReview(authorization, projectId, request);
+
+        // then
+        ArgumentCaptor<FreelancerReviewCreateRequest> captor = ArgumentCaptor.forClass(FreelancerReviewCreateRequest.class);
+        verify(reviewService, times(1)).createFreelancerReview(org.mockito.ArgumentMatchers.eq(freelancerId), captor.capture());
+        assertEquals(projectId, captor.getValue().projectId());
+        assertEquals(41L, captor.getValue().employerId());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(888L, response.getBody().data());
+    }
+
+    @Test
+    @DisplayName("[TDD] 프리랜서 수신 리뷰 조회 시 page/size를 안전값으로 보정해 서비스에 전달한다")
+    void getFreelancerReceivedReviews_clampsPageAndSize() {
+        // given
+        String authorization = "Bearer token";
+        when(reviewTokenUserIdResolver.resolveUserId(authorization)).thenReturn(31L);
+        Page<EmployerReview> page = new PageImpl<>(List.of());
+        when(reviewService.getFreelancerReceivedReviews(org.mockito.ArgumentMatchers.eq(31L), org.mockito.ArgumentMatchers.any()))
+                .thenReturn(page);
+
+        // when
+        controller.getFreelancerReceivedReviews(authorization, -1, 1000);
+
+        // then
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(reviewService, times(1)).getFreelancerReceivedReviews(org.mockito.ArgumentMatchers.eq(31L), pageableCaptor.capture());
+        assertEquals(0, pageableCaptor.getValue().getPageNumber());
+        assertEquals(100, pageableCaptor.getValue().getPageSize());
+    }
+}

--- a/freebridge/review/src/test/java/com/fallguys/review/service/ReviewServiceImplTest.java
+++ b/freebridge/review/src/test/java/com/fallguys/review/service/ReviewServiceImplTest.java
@@ -1,0 +1,208 @@
+package com.fallguys.review.service;
+
+import com.fallguys.common.exception.BusinessException;
+import com.fallguys.common.exception.ErrorCode;
+import com.fallguys.review.api.dto.request.EmployerReviewCreateRequest;
+import com.fallguys.review.api.dto.request.EmployerReviewUpdateRequest;
+import com.fallguys.review.api.dto.request.FreelancerReviewCreateRequest;
+import com.fallguys.review.api.dto.request.FreelancerReviewUpdateRequest;
+import com.fallguys.review.entity.EmployerReview;
+import com.fallguys.review.entity.FreelancerReview;
+import com.fallguys.review.entity.ReviewStatus;
+import com.fallguys.review.repository.EmployerReviewRepository;
+import com.fallguys.review.repository.FreelancerReviewRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.sql.SQLException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceImplTest {
+
+    @Mock
+    private EmployerReviewRepository employerReviewRepository;
+
+    @Mock
+    private FreelancerReviewRepository freelancerReviewRepository;
+
+    @InjectMocks
+    private ReviewServiceImpl reviewService;
+
+    @Test
+    @DisplayName("[TDD] 고용주 리뷰 생성 시 ACTIVE 중복 데이터가 있으면 INVALID_INPUT_VALUE 예외")
+    void createEmployerReview_whenAlreadyExists_throwsBusinessException() {
+        // given
+        Long employerId = 1L;
+        EmployerReviewCreateRequest request = new EmployerReviewCreateRequest(10L, 20L, 5, 5, 5, 5, 5, 5, "desc");
+        when(employerReviewRepository.findByProjectIdAndEmployerIdAndFreelancerIdAndStatus(
+                request.projectId(), employerId, request.freelancerId(), ReviewStatus.ACTIVE
+        )).thenReturn(Optional.of(EmployerReview.builder().id(99L).build()));
+
+        // when
+        BusinessException ex = assertThrows(BusinessException.class, () -> reviewService.createEmployerReview(employerId, request));
+
+        // then
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("[TDD] 고용주 리뷰 생성 성공 시 저장된 리뷰 ID를 반환한다")
+    void createEmployerReview_success_returnsSavedId() {
+        // given
+        Long employerId = 1L;
+        EmployerReviewCreateRequest request = new EmployerReviewCreateRequest(10L, 20L, 4, 4, 4, 4, 4, 4, "good");
+        when(employerReviewRepository.findByProjectIdAndEmployerIdAndFreelancerIdAndStatus(
+                request.projectId(), employerId, request.freelancerId(), ReviewStatus.ACTIVE
+        )).thenReturn(Optional.empty());
+        when(employerReviewRepository.save(any())).thenReturn(EmployerReview.builder().id(123L).build());
+
+        // when
+        Long reviewId = reviewService.createEmployerReview(employerId, request);
+
+        // then
+        assertEquals(123L, reviewId);
+        ArgumentCaptor<EmployerReview> captor = ArgumentCaptor.forClass(EmployerReview.class);
+        verify(employerReviewRepository, times(1)).save(captor.capture());
+        assertEquals(employerId, captor.getValue().getEmployerId());
+        assertEquals(request.freelancerId(), captor.getValue().getFreelancerId());
+    }
+
+    @Test
+    @DisplayName("[TDD] 고용주 리뷰 생성 시 중복키 예외(SQLState 23505)는 BusinessException으로 변환")
+    void createEmployerReview_duplicateSqlState_throwsBusinessException() {
+        // given
+        Long employerId = 1L;
+        EmployerReviewCreateRequest request = new EmployerReviewCreateRequest(10L, 20L, 3, 3, 3, 3, 3, 3, "dup");
+        when(employerReviewRepository.findByProjectIdAndEmployerIdAndFreelancerIdAndStatus(
+                request.projectId(), employerId, request.freelancerId(), ReviewStatus.ACTIVE
+        )).thenReturn(Optional.empty());
+        DataIntegrityViolationException ex = new DataIntegrityViolationException(
+                "duplicate", new SQLException("duplicate key", "23505")
+        );
+        when(employerReviewRepository.save(any())).thenThrow(ex);
+
+        // when
+        BusinessException thrown = assertThrows(BusinessException.class, () -> reviewService.createEmployerReview(employerId, request));
+
+        // then
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, thrown.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("[TDD] 고용주 리뷰 수정 시 대상 리뷰를 찾아 값이 갱신된다")
+    void updateEmployerReview_updatesFields() {
+        // given
+        Long employerId = 2L;
+        Long reviewId = 3L;
+        EmployerReview review = EmployerReview.builder()
+                .id(reviewId).employerId(employerId).freelancerId(30L)
+                .language(1).framework(1).debugging(1).communication(1).schedule(1).dispute(1)
+                .description("old").status(ReviewStatus.ACTIVE).build();
+        EmployerReviewUpdateRequest request = new EmployerReviewUpdateRequest(5, 4, 3, 2, 1, 5, "new");
+        when(employerReviewRepository.findByIdAndEmployerIdAndStatus(reviewId, employerId, ReviewStatus.ACTIVE))
+                .thenReturn(Optional.of(review));
+
+        // when
+        reviewService.updateEmployerReview(employerId, reviewId, request);
+
+        // then
+        assertEquals(5, review.getLanguage());
+        assertEquals(4, review.getFramework());
+        assertEquals("new", review.getDescription());
+    }
+
+    @Test
+    @DisplayName("[TDD] 고용주 리뷰 삭제 시 soft delete 처리된다")
+    void deleteEmployerReview_softDeletes() {
+        // given
+        Long employerId = 2L;
+        Long reviewId = 4L;
+        EmployerReview review = EmployerReview.builder()
+                .id(reviewId).employerId(employerId).status(ReviewStatus.ACTIVE).build();
+        when(employerReviewRepository.findByIdAndEmployerIdAndStatus(reviewId, employerId, ReviewStatus.ACTIVE))
+                .thenReturn(Optional.of(review));
+
+        // when
+        reviewService.deleteEmployerReview(employerId, reviewId);
+
+        // then
+        assertEquals(ReviewStatus.DELETED, review.getStatus());
+    }
+
+    @Test
+    @DisplayName("[TDD] 프리랜서 리뷰 생성 성공 시 저장된 리뷰 ID를 반환한다")
+    void createFreelancerReview_success_returnsSavedId() {
+        // given
+        Long freelancerId = 7L;
+        FreelancerReviewCreateRequest request = new FreelancerReviewCreateRequest(100L, 200L, 5, 4, 3, "ok");
+        when(freelancerReviewRepository.findByProjectIdAndFreelancerIdAndEmployerIdAndStatus(
+                request.projectId(), freelancerId, request.employerId(), ReviewStatus.ACTIVE
+        )).thenReturn(Optional.empty());
+        when(freelancerReviewRepository.save(any())).thenReturn(FreelancerReview.builder().id(55L).build());
+
+        // when
+        Long reviewId = reviewService.createFreelancerReview(freelancerId, request);
+
+        // then
+        assertEquals(55L, reviewId);
+        ArgumentCaptor<FreelancerReview> captor = ArgumentCaptor.forClass(FreelancerReview.class);
+        verify(freelancerReviewRepository, times(1)).save(captor.capture());
+        assertEquals(freelancerId, captor.getValue().getFreelancerId());
+        assertEquals(request.employerId(), captor.getValue().getEmployerId());
+    }
+
+    @Test
+    @DisplayName("[TDD] 프리랜서 리뷰 수정 시 대상 리뷰를 찾아 값이 갱신된다")
+    void updateFreelancerReview_updatesFields() {
+        // given
+        Long freelancerId = 8L;
+        Long reviewId = 9L;
+        FreelancerReview review = FreelancerReview.builder()
+                .id(reviewId).freelancerId(freelancerId).employerId(300L)
+                .atmosphere(1).requirementDetail(1).schedule(1).description("old")
+                .status(ReviewStatus.ACTIVE).build();
+        FreelancerReviewUpdateRequest request = new FreelancerReviewUpdateRequest(2, 3, 4, "new");
+        when(freelancerReviewRepository.findByIdAndFreelancerIdAndStatus(reviewId, freelancerId, ReviewStatus.ACTIVE))
+                .thenReturn(Optional.of(review));
+
+        // when
+        reviewService.updateFreelancerReview(freelancerId, reviewId, request);
+
+        // then
+        assertEquals(2, review.getAtmosphere());
+        assertEquals(3, review.getRequirementDetail());
+        assertEquals("new", review.getDescription());
+    }
+
+    @Test
+    @DisplayName("[TDD] 프리랜서 리뷰 삭제 시 soft delete 처리된다")
+    void deleteFreelancerReview_softDeletes() {
+        // given
+        Long freelancerId = 8L;
+        Long reviewId = 10L;
+        FreelancerReview review = FreelancerReview.builder()
+                .id(reviewId).freelancerId(freelancerId).status(ReviewStatus.ACTIVE).build();
+        when(freelancerReviewRepository.findByIdAndFreelancerIdAndStatus(reviewId, freelancerId, ReviewStatus.ACTIVE))
+                .thenReturn(Optional.of(review));
+
+        // when
+        reviewService.deleteFreelancerReview(freelancerId, reviewId);
+
+        // then
+        assertEquals(ReviewStatus.DELETED, review.getStatus());
+    }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #미기재

## 📝 작업 내용
`review` 모듈(`com.fallguys.review`)에 대해 서비스/컨트롤러 단위 테스트를 신규 추가했습니다.  
리뷰 생성/수정/삭제 핵심 로직과 컨트롤러의 요청 병합(`projectId`) 및 페이지 파라미터 보정 로직을 검증하도록 구성했습니다.

## ✅ Changes
- `ReviewServiceImpl` 테스트 추가
- 고용주 리뷰 생성 시 중복 데이터 존재 시 예외(`INVALID_INPUT_VALUE`) 검증
- 고용주 리뷰 생성 성공 시 저장 ID 반환 및 저장 값 매핑 검증
- 고용주 리뷰 생성 중 DB 중복키 예외(SQLState `23505`) 처리 검증
- 고용주 리뷰 수정 필드 반영 및 삭제(soft delete) 검증
- 프리랜서 리뷰 생성 성공 시 저장 ID 반환/매핑 검증
- 프리랜서 리뷰 수정 필드 반영 및 삭제(soft delete) 검증
- `EmployerReviewController` 테스트 추가
- 생성 API에서 path variable `projectId`를 DTO에 merge 후 서비스 호출하는지 검증
- 조회 API에서 `page/size` 안전 보정(`page >= 0`, `size <= 100`) 검증
- `FreelancerReviewController` 테스트 추가
- 생성 API `projectId` merge 검증
- 조회 API `page/size` 보정 검증
- 테스트 실행 검증 완료  
  - `:review:test --tests ...` 실행 결과 `BUILD SUCCESSFUL`

## 📸 스크린샷 (선택)
테스트 실행 결과 콘솔/리포트 캡처 첨부 예정

## ⚠️ Notes (Optional)
- 이번 변경은 테스트 코드만 추가했으며, 프로덕션 로직 변경은 없습니다.
- 이슈 번호 확정 후 `Closes #...` 갱신이 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 고용주 리뷰 컨트롤러에 대한 단위 테스트 추가
  * 프리랜서 리뷰 컨트롤러에 대한 단위 테스트 추가
  * 리뷰 서비스에 대한 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->