### PR TITLE
HFP-73 [feat] Match Test

### DIFF
--- a/freebridge/matchs/build.gradle
+++ b/freebridge/matchs/build.gradle
@@ -10,5 +10,6 @@ dependencies {
     implementation project(':user')
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     compileOnly 'io.jsonwebtoken:jjwt-api:0.13.0'
+    testImplementation 'io.jsonwebtoken:jjwt-api:0.13.0'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui'
 }

--- a/freebridge/matchs/src/test/java/com/fallguys/matchs/api/support/TokenUserIdResolverTest.java
+++ b/freebridge/matchs/src/test/java/com/fallguys/matchs/api/support/TokenUserIdResolverTest.java
@@ -1,0 +1,61 @@
+package com.fallguys.matchs.api.support;
+
+import com.fallguys.common.exception.BusinessException;
+import com.fallguys.common.exception.ErrorCode;
+import com.fallguys.common.security.JwtTokenProvider;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TokenUserIdResolverTest {
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks
+    private TokenUserIdResolver resolver;
+
+    @Mock
+    private Claims claims;
+
+    @Test
+    @DisplayName("[TDD] 헤더가 Bearer 형식이 아니면 INVALID_INPUT_VALUE 예외")
+    void resolveUserId_invalidHeader_throws() {
+        BusinessException ex = assertThrows(BusinessException.class, () -> resolver.resolveUserId("Token abc"));
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("[TDD] subject가 숫자면 userId로 반환")
+    void resolveUserId_subjectNumber_returnsId() {
+        when(jwtTokenProvider.validateToken("ok")).thenReturn(true);
+        when(jwtTokenProvider.getClaimsFromToken("ok")).thenReturn(claims);
+        when(claims.getSubject()).thenReturn("101");
+
+        Long userId = resolver.resolveUserId("Bearer ok");
+
+        assertEquals(101L, userId);
+    }
+
+    @Test
+    @DisplayName("[TDD] subject가 비숫자면 id 클레임(Number)으로 fallback")
+    void resolveUserId_fallbackToIdClaim() {
+        when(jwtTokenProvider.validateToken("ok")).thenReturn(true);
+        when(jwtTokenProvider.getClaimsFromToken("ok")).thenReturn(claims);
+        when(claims.getSubject()).thenReturn("legacy");
+        when(claims.get("id")).thenReturn(202L);
+
+        Long userId = resolver.resolveUserId("Bearer ok");
+
+        assertEquals(202L, userId);
+    }
+}

--- a/freebridge/matchs/src/test/java/com/fallguys/matchs/api/web/MatchsControllerTest.java
+++ b/freebridge/matchs/src/test/java/com/fallguys/matchs/api/web/MatchsControllerTest.java
@@ -1,0 +1,86 @@
+package com.fallguys.matchs.api.web;
+
+import com.fallguys.common.response.ApiResponse;
+import com.fallguys.matchs.api.dto.request.ApplicationCreateRequest;
+import com.fallguys.matchs.api.dto.response.ProposalResponseDTO;
+import com.fallguys.matchs.api.support.TokenUserIdResolver;
+import com.fallguys.matchs.entity.MatchsStatus;
+import com.fallguys.matchs.service.MatchsService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MatchsControllerTest {
+
+    @Mock
+    private MatchsService matchsService;
+
+    @Mock
+    private TokenUserIdResolver tokenUserIdResolver;
+
+    @InjectMocks
+    private MatchsController controller;
+
+    @Test
+    @DisplayName("[TDD] 지원 생성 API는 토큰 userId를 해석해 서비스 호출 후 applicationId를 반환")
+    void createApplication_callsServiceAndReturnsId() {
+        // given
+        String authorization = "Bearer token";
+        ApplicationCreateRequest request = new ApplicationCreateRequest(10L, "message");
+        when(tokenUserIdResolver.resolveUserId(authorization)).thenReturn(3L);
+        when(matchsService.createApplication(3L, request)).thenReturn(77L);
+
+        // when
+        ResponseEntity<ApiResponse<Map<String, Long>>> response = controller.createApplication(authorization, request);
+
+        // then
+        verify(matchsService, times(1)).createApplication(3L, request);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(77L, response.getBody().data().get("applicationId"));
+    }
+
+    @Test
+    @DisplayName("[TDD] 고용주 제안 목록 조회 API는 page/size를 안전값으로 보정한다")
+    void getEmployerProposals_clampsPageAndSize() {
+        // given
+        String authorization = "Bearer token";
+        when(tokenUserIdResolver.resolveUserId(authorization)).thenReturn(5L);
+        Page<ProposalResponseDTO> page = new PageImpl<>(List.of(
+                new ProposalResponseDTO(1L, 2L, 3L, 5L, "msg", MatchsStatus.PENDING, LocalDateTime.now())
+        ));
+        when(matchsService.getEmployerProposals(org.mockito.ArgumentMatchers.eq(5L), org.mockito.ArgumentMatchers.any()))
+                .thenReturn(page);
+
+        // when
+        ResponseEntity<ApiResponse<com.fallguys.matchs.api.dto.response.PagedResponseDTO<ProposalResponseDTO>>> response =
+                controller.getEmployerProposals(authorization, -1, 999);
+
+        // then
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(matchsService, times(1)).getEmployerProposals(org.mockito.ArgumentMatchers.eq(5L), pageableCaptor.capture());
+        assertEquals(0, pageableCaptor.getValue().getPageNumber());
+        assertEquals(100, pageableCaptor.getValue().getPageSize());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+}

--- a/freebridge/matchs/src/test/java/com/fallguys/matchs/service/MatchsServiceImplTest.java
+++ b/freebridge/matchs/src/test/java/com/fallguys/matchs/service/MatchsServiceImplTest.java
@@ -1,0 +1,237 @@
+package com.fallguys.matchs.service;
+
+import com.fallguys.common.exception.BusinessException;
+import com.fallguys.common.exception.ErrorCode;
+import com.fallguys.matchs.api.dto.request.ApplicationCreateRequest;
+import com.fallguys.matchs.api.dto.request.ProposalCreateRequest;
+import com.fallguys.matchs.entity.Application;
+import com.fallguys.matchs.entity.MatchsStatus;
+import com.fallguys.matchs.entity.Proposal;
+import com.fallguys.matchs.repository.ApplicationRepo;
+import com.fallguys.matchs.repository.ProposalRepo;
+import com.fallguys.recruitment.api.dto.request.JobPostingCreateDTO;
+import com.fallguys.recruitment.entity.JobPosting;
+import com.fallguys.recruitment.entity.Project;
+import com.fallguys.recruitment.entity.Status;
+import com.fallguys.recruitment.repository.JobPostingRepo;
+import com.fallguys.recruitment.repository.ProjectPostingRepo;
+import com.fallguys.user.entity.Role;
+import com.fallguys.user.entity.User;
+import com.fallguys.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MatchsServiceImplTest {
+
+    @Mock
+    private ApplicationRepo applicationRepo;
+    @Mock
+    private ProposalRepo proposalRepo;
+    @Mock
+    private JobPostingRepo jobPostingRepo;
+    @Mock
+    private ProjectPostingRepo projectPostingRepo;
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private MatchsServiceImpl matchsService;
+
+    @Test
+    @DisplayName("[TDD] 지원 생성 시 프리랜서/공고 소유자 정보로 Application 저장")
+    void createApplication_savesApplication() {
+        // given
+        Long freelancerId = 10L;
+        Long jobPostingId = 100L;
+        when(userRepository.findById(freelancerId)).thenReturn(Optional.of(user(Role.FREELANCER)));
+        when(jobPostingRepo.findById(jobPostingId))
+                .thenReturn(Optional.of(jobPosting(jobPostingId, 88L, Status.ACTIVE, 2, 0)));
+        when(applicationRepo.save(any())).thenAnswer(invocation -> {
+            Application app = invocation.getArgument(0);
+            ReflectionTestUtils.setField(app, "id", 1L, Long.class);
+            return app;
+        });
+
+        // when
+        Long id = matchsService.createApplication(freelancerId, new ApplicationCreateRequest(jobPostingId, "hello"));
+
+        // then
+        assertEquals(1L, id);
+        ArgumentCaptor<Application> captor = ArgumentCaptor.forClass(Application.class);
+        verify(applicationRepo, times(1)).save(captor.capture());
+        assertEquals(freelancerId, captor.getValue().getFreelancerId());
+        assertEquals(88L, captor.getValue().getEmployerId());
+        assertEquals(MatchsStatus.PENDING, captor.getValue().getStatus());
+    }
+
+    @Test
+    @DisplayName("[TDD] 지원 생성 시 사용자 Role이 프리랜서가 아니면 ONLY_FREELANCER_ALLOWED 예외")
+    void createApplication_nonFreelancer_throws() {
+        // given
+        Long userId = 11L;
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user(Role.EMPLOYER)));
+
+        // when
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> matchsService.createApplication(userId, new ApplicationCreateRequest(1L, "msg"))
+        );
+
+        // then
+        assertEquals(ErrorCode.ONLY_FREELANCER_ALLOWED, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("[TDD] 제안 생성 시 고용주가 공고 소유자가 아니면 JOB_POSTING_FORBIDDEN 예외")
+    void createProposal_notOwner_throws() {
+        // given
+        Long employerId = 2L;
+        ProposalCreateRequest request = new ProposalCreateRequest(200L, 3L, "msg");
+        when(userRepository.findById(employerId)).thenReturn(Optional.of(user(Role.EMPLOYER)));
+        when(userRepository.findById(request.freelancerId())).thenReturn(Optional.of(user(Role.FREELANCER)));
+        when(jobPostingRepo.findById(request.jobPostingId()))
+                .thenReturn(Optional.of(jobPosting(200L, 99L, Status.ACTIVE, 2, 0)));
+
+        // when
+        BusinessException ex = assertThrows(BusinessException.class, () -> matchsService.createProposal(employerId, request));
+
+        // then
+        assertEquals(ErrorCode.JOB_POSTING_FORBIDDEN, ex.getErrorCode());
+        verify(proposalRepo, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("[TDD] 지원 수락 시 기존 프로젝트가 있으면 해당 프로젝트 ID를 반환")
+    void acceptApplication_existingProject_returnsExistingId() {
+        // given
+        Long employerId = 1L;
+        Long applicationId = 10L;
+        Application application = Application.create(300L, 20L, employerId, "apply");
+        ReflectionTestUtils.setField(application, "id", applicationId, Long.class);
+
+        Project existingProject = Project.create(jobPosting(300L, employerId, Status.ACTIVE, 2, 0), 20L);
+        ReflectionTestUtils.setField(existingProject, "id", 777L, Long.class);
+
+        when(userRepository.findById(employerId)).thenReturn(Optional.of(user(Role.EMPLOYER)));
+        when(applicationRepo.findById(applicationId)).thenReturn(Optional.of(application));
+        when(jobPostingRepo.findByIdForUpdate(300L))
+                .thenReturn(Optional.of(jobPosting(300L, employerId, Status.ACTIVE, 2, 0)));
+        when(projectPostingRepo.findByJobPostingIdAndFreelancerId(300L, 20L)).thenReturn(Optional.of(existingProject));
+
+        // when
+        Long projectId = matchsService.acceptApplication(employerId, applicationId);
+
+        // then
+        assertEquals(777L, projectId);
+        assertEquals(MatchsStatus.ACCEPTED, application.getStatus());
+        verify(projectPostingRepo, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("[TDD] 지원 수락 시 신규 프로젝트 생성 후 projectId를 반환")
+    void acceptApplication_createsProject() {
+        // given
+        Long employerId = 1L;
+        Long applicationId = 11L;
+        Application application = Application.create(301L, 21L, employerId, "apply");
+        ReflectionTestUtils.setField(application, "id", applicationId, Long.class);
+        JobPosting posting = jobPosting(301L, employerId, Status.ACTIVE, 2, 0);
+
+        when(userRepository.findById(employerId)).thenReturn(Optional.of(user(Role.EMPLOYER)));
+        when(applicationRepo.findById(applicationId)).thenReturn(Optional.of(application));
+        when(jobPostingRepo.findByIdForUpdate(301L)).thenReturn(Optional.of(posting));
+        when(projectPostingRepo.findByJobPostingIdAndFreelancerId(301L, 21L)).thenReturn(Optional.empty());
+        when(projectPostingRepo.save(any())).thenAnswer(invocation -> {
+            Project project = invocation.getArgument(0);
+            ReflectionTestUtils.setField(project, "id", 900L, Long.class);
+            return project;
+        });
+
+        // when
+        Long projectId = matchsService.acceptApplication(employerId, applicationId);
+
+        // then
+        assertEquals(900L, projectId);
+        assertEquals(1, posting.getMatchedHeadcount());
+    }
+
+    @Test
+    @DisplayName("[TDD] 제안 거절 시 상태가 PENDING이 아니면 INVALID_INPUT_VALUE 예외")
+    void rejectProposal_notPending_throws() {
+        // given
+        Long freelancerId = 33L;
+        Long proposalId = 44L;
+        Proposal proposal = Proposal.create(1L, freelancerId, 77L, "msg");
+        proposal.accept();
+        ReflectionTestUtils.setField(proposal, "id", proposalId, Long.class);
+        when(userRepository.findById(freelancerId)).thenReturn(Optional.of(user(Role.FREELANCER)));
+        when(proposalRepo.findById(proposalId)).thenReturn(Optional.of(proposal));
+
+        // when
+        BusinessException ex = assertThrows(BusinessException.class, () -> matchsService.rejectProposal(freelancerId, proposalId));
+
+        // then
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("[TDD] 고용주 지원 상세 조회 시 소유자가 다르면 JOB_POSTING_FORBIDDEN 예외")
+    void getEmployerApplication_forbidden_throws() {
+        // given
+        Long employerId = 1L;
+        Long applicationId = 55L;
+        Application application = Application.create(10L, 20L, 99L, "msg");
+        ReflectionTestUtils.setField(application, "id", applicationId, Long.class);
+        when(userRepository.findById(employerId)).thenReturn(Optional.of(user(Role.EMPLOYER)));
+        when(applicationRepo.findById(applicationId)).thenReturn(Optional.of(application));
+
+        // when
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> matchsService.getEmployerApplication(employerId, applicationId)
+        );
+
+        // then
+        assertEquals(ErrorCode.JOB_POSTING_FORBIDDEN, ex.getErrorCode());
+    }
+
+    private User user(Role role) {
+        return User.builder()
+                .email(role.name().toLowerCase() + "@test.com")
+                .password("pw")
+                .name("name")
+                .role(role)
+                .termsAgreed(true)
+                .privacyAgreed(true)
+                .build();
+    }
+
+    private JobPosting jobPosting(Long id, Long employerId, Status status, int headcount, int matched) {
+        JobPosting posting = JobPosting.from(
+                new JobPostingCreateDTO("title", "desc", java.util.List.of("Java"), 1000L, 3, headcount),
+                employerId,
+                "employer"
+        );
+        ReflectionTestUtils.setField(posting, "id", id, Long.class);
+        ReflectionTestUtils.setField(posting, "status", status);
+        ReflectionTestUtils.setField(posting, "matchedHeadcount", matched);
+        return posting;
+    }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #미기재

## 📝 작업 내용
`matchs` 모듈(`com.fallguys.matchs`)에 단위 테스트를 신규 추가했습니다.  
서비스 핵심 비즈니스 로직(지원/제안 생성, 수락/거절, 권한/상태 검증), 토큰 파싱 로직, 컨트롤러 요청 처리 흐름을 검증하도록 구성했습니다.

## ✅ Changes
- `matchs/build.gradle` 테스트 의존성 추가
- `testImplementation 'io.jsonwebtoken:jjwt-api:0.13.0'` 추가
- `MatchsServiceImplTest` 추가
- 지원 생성 성공 시 저장 엔티티 매핑 검증
- 프리랜서 권한 불일치 시 `ONLY_FREELANCER_ALLOWED` 예외 검증
- 제안 생성 시 공고 소유자 불일치 시 `JOB_POSTING_FORBIDDEN` 예외 검증
- 지원 수락 시 기존 프로젝트가 있으면 기존 프로젝트 ID 반환 검증
- 지원 수락 시 신규 프로젝트 생성 및 공고 `matchedHeadcount` 증가 검증
- 제안 거절 시 상태가 `PENDING`이 아닐 때 `INVALID_INPUT_VALUE` 예외 검증
- 고용주 지원 상세 조회 권한 불일치 시 `JOB_POSTING_FORBIDDEN` 검증
- `TokenUserIdResolverTest` 추가
- Authorization 형식 오류 예외 검증
- JWT `subject` 기반 userId 파싱 검증
- legacy `id` claim fallback 파싱 검증
- `MatchsControllerTest` 추가
- 지원 생성 API의 토큰 해석 → 서비스 호출 → 응답 payload(`applicationId`) 검증
- 고용주 제안 목록 API의 `page/size` 안전 보정(`page>=0`, `size<=100`) 검증
- 테스트 실행 확인
- `:matchs:test --tests ...` 실행 결과 `BUILD SUCCESSFUL`

## 📸 스크린샷 (선택)
테스트 실행 콘솔/리포트 캡처 첨부 예정

## ⚠️ Notes (Optional)
- 이번 PR은 테스트 코드 및 테스트 의존성만 변경했습니다. (프로덕션 로직 변경 없음)
- 이슈 번호 확정 후 `Closes #...` 갱신이 필요합니다.