### PR TITLE
HFP-74 [feat] JobPosting Test

### DIFF
--- a/freebridge/recruitment/build.gradle
+++ b/freebridge/recruitment/build.gradle
@@ -10,5 +10,6 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     compileOnly 'io.jsonwebtoken:jjwt-api:0.13.0'
+    testImplementation 'io.jsonwebtoken:jjwt-api:0.13.0'
     compileOnly 'org.springdoc:springdoc-openapi-starter-webmvc-ui'
 }

--- a/freebridge/recruitment/src/test/java/com/fallguys/recruitment/api/support/TokenUserIdResolverTest.java
+++ b/freebridge/recruitment/src/test/java/com/fallguys/recruitment/api/support/TokenUserIdResolverTest.java
@@ -1,0 +1,61 @@
+package com.fallguys.recruitment.api.support;
+
+import com.fallguys.common.exception.BusinessException;
+import com.fallguys.common.exception.ErrorCode;
+import com.fallguys.common.security.JwtTokenProvider;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TokenUserIdResolverTest {
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks
+    private TokenUserIdResolver resolver;
+
+    @Mock
+    private Claims claims;
+
+    @Test
+    @DisplayName("[TDD] Authorization 형식이 잘못되면 INVALID_INPUT_VALUE 예외")
+    void resolveUserId_invalidHeader_throws() {
+        BusinessException ex = assertThrows(BusinessException.class, () -> resolver.resolveUserId("Token abc"));
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("[TDD] subject가 숫자면 userId로 반환")
+    void resolveUserId_subjectNumber_returnsId() {
+        when(jwtTokenProvider.validateToken("ok")).thenReturn(true);
+        when(jwtTokenProvider.getClaimsFromToken("ok")).thenReturn(claims);
+        when(claims.getSubject()).thenReturn("101");
+
+        Long userId = resolver.resolveUserId("Bearer ok");
+
+        assertEquals(101L, userId);
+    }
+
+    @Test
+    @DisplayName("[TDD] subject가 비숫자면 id(Number) claim으로 fallback")
+    void resolveUserId_fallbackToIdClaim() {
+        when(jwtTokenProvider.validateToken("ok")).thenReturn(true);
+        when(jwtTokenProvider.getClaimsFromToken("ok")).thenReturn(claims);
+        when(claims.getSubject()).thenReturn("legacy");
+        when(claims.get("id")).thenReturn(202L);
+
+        Long userId = resolver.resolveUserId("Bearer ok");
+
+        assertEquals(202L, userId);
+    }
+}

--- a/freebridge/recruitment/src/test/java/com/fallguys/recruitment/api/web/JobPostingEmployerControllerTest.java
+++ b/freebridge/recruitment/src/test/java/com/fallguys/recruitment/api/web/JobPostingEmployerControllerTest.java
@@ -1,0 +1,82 @@
+package com.fallguys.recruitment.api.web;
+
+import com.fallguys.common.response.ApiResponse;
+import com.fallguys.recruitment.api.dto.request.JobPostingCreateDTO;
+import com.fallguys.recruitment.api.dto.response.JobPostingSearchDTO;
+import com.fallguys.recruitment.api.dto.response.PagedResponseDTO;
+import com.fallguys.recruitment.api.support.TokenUserIdResolver;
+import com.fallguys.recruitment.entity.JobPostingStatus;
+import com.fallguys.recruitment.service.JobPostingService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JobPostingEmployerControllerTest {
+
+    @Mock
+    private JobPostingService jobPostingService;
+
+    @Mock
+    private TokenUserIdResolver tokenUserIdResolver;
+
+    @InjectMocks
+    private JobPostingEmployerController controller;
+
+    @Test
+    @DisplayName("[TDD] 채용 공고 생성 API는 토큰 userId를 해석해 서비스에 전달하고 200 반환")
+    void createJobPosting_callsServiceAndReturnsOk() {
+        // given
+        String authorization = "Bearer token";
+        JobPostingCreateDTO body = new JobPostingCreateDTO("Backend", "desc", List.of("Java"), 1000L, 3, 2);
+        when(tokenUserIdResolver.resolveUserId(authorization)).thenReturn(10L);
+
+        // when
+        ResponseEntity<ApiResponse<Void>> response = controller.createJobPosting(authorization, body);
+
+        // then
+        verify(jobPostingService, times(1)).createJobPosting(body, 10L);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(true, response.getBody().success());
+    }
+
+    @Test
+    @DisplayName("[TDD] 내 공고 조회 API는 PagingUtils를 통해 page/size를 보정해 응답한다")
+    void getMyJobPostings_appliesPagingSafety() {
+        // given
+        String authorization = "Bearer token";
+        when(tokenUserIdResolver.resolveUserId(authorization)).thenReturn(10L);
+        when(jobPostingService.getJobPostings(10L)).thenReturn(List.of(
+                new JobPostingSearchDTO(1L, "emp", "t1", "d1", List.of("Java"), 100L, 1, 1, 0, JobPostingStatus.OPEN),
+                new JobPostingSearchDTO(2L, "emp", "t2", "d2", List.of("Spring"), 200L, 2, 2, 0, JobPostingStatus.IN_PROGRESS)
+        ));
+
+        // when
+        ResponseEntity<ApiResponse<PagedResponseDTO<JobPostingSearchDTO>>> response =
+                controller.getMyJobPostings(authorization, -3, 0);
+
+        // then
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        PagedResponseDTO<JobPostingSearchDTO> paged = response.getBody().data();
+        assertEquals(0, paged.page());
+        assertEquals(1, paged.size());
+        assertEquals(2L, paged.totalElements());
+        assertEquals(2, paged.totalPages());
+        assertEquals(1, paged.content().size());
+    }
+}

--- a/freebridge/recruitment/src/test/java/com/fallguys/recruitment/api/web/JobPostingFreelancerControllerTest.java
+++ b/freebridge/recruitment/src/test/java/com/fallguys/recruitment/api/web/JobPostingFreelancerControllerTest.java
@@ -1,0 +1,79 @@
+package com.fallguys.recruitment.api.web;
+
+import com.fallguys.common.response.ApiResponse;
+import com.fallguys.recruitment.api.dto.response.AiRecommendationResponseDTO;
+import com.fallguys.recruitment.api.dto.response.FreelancerJobPostingSearchDTO;
+import com.fallguys.recruitment.api.dto.response.PagedResponseDTO;
+import com.fallguys.recruitment.api.support.TokenUserIdResolver;
+import com.fallguys.recruitment.service.JobPostingService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JobPostingFreelancerControllerTest {
+
+    @Mock
+    private JobPostingService jobPostingService;
+
+    @Mock
+    private TokenUserIdResolver tokenUserIdResolver;
+
+    @InjectMocks
+    private JobPostingFreelancerController controller;
+
+    @Test
+    @DisplayName("[TDD] 공고 검색 API는 liked/keyword를 전달하고 페이징 응답을 반환한다")
+    void searchJobPostings_returnsPagedResponse() {
+        // given
+        String authorization = "Bearer token";
+        when(tokenUserIdResolver.resolveUserId(authorization)).thenReturn(21L);
+        when(jobPostingService.searchJobPostingsForFreelancer(21L, "java", true)).thenReturn(List.of(
+                new FreelancerJobPostingSearchDTO(1L, "emp", "Backend", "desc", List.of("Java"), 100L, 3, 1, 0, true)
+        ));
+
+        // when
+        ResponseEntity<ApiResponse<PagedResponseDTO<FreelancerJobPostingSearchDTO>>> response =
+                controller.searchJobPostings(authorization, "java", true, 0, 10);
+
+        // then
+        verify(jobPostingService, times(1)).searchJobPostingsForFreelancer(21L, "java", true);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(1, response.getBody().data().content().size());
+    }
+
+    @Test
+    @DisplayName("[TDD] 추천 공고 조회 API는 토큰 userId로 서비스 호출 후 결과 반환")
+    void getMyJobRecommendations_callsServiceAndReturns() {
+        // given
+        String authorization = "Bearer token";
+        when(tokenUserIdResolver.resolveUserId(authorization)).thenReturn(21L);
+        when(jobPostingService.getRecommendedJobsForFreelancer(21L)).thenReturn(List.of(
+                new AiRecommendationResponseDTO(1L, "추천공고", 0.93)
+        ));
+
+        // when
+        ResponseEntity<ApiResponse<List<AiRecommendationResponseDTO>>> response =
+                controller.getMyJobRecommendations(authorization);
+
+        // then
+        verify(jobPostingService, times(1)).getRecommendedJobsForFreelancer(21L);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(1, response.getBody().data().size());
+    }
+}

--- a/freebridge/recruitment/src/test/java/com/fallguys/recruitment/service/JobPostingServiceCoreTest.java
+++ b/freebridge/recruitment/src/test/java/com/fallguys/recruitment/service/JobPostingServiceCoreTest.java
@@ -1,0 +1,184 @@
+package com.fallguys.recruitment.service;
+
+import com.fallguys.common.ai.port.RecommendationEngine;
+import com.fallguys.common.exception.BusinessException;
+import com.fallguys.common.exception.ErrorCode;
+import com.fallguys.recruitment.api.dto.request.JobPostingCreateDTO;
+import com.fallguys.recruitment.api.dto.request.JobPostingUpdateDTO;
+import com.fallguys.recruitment.api.dto.response.AiRecommendationResponseDTO;
+import com.fallguys.recruitment.entity.JobPosting;
+import com.fallguys.recruitment.entity.JobPostingStatus;
+import com.fallguys.recruitment.entity.Project;
+import com.fallguys.recruitment.entity.ProjectStatus;
+import com.fallguys.recruitment.entity.Status;
+import com.fallguys.recruitment.repository.JobPostingFavoriteRepo;
+import com.fallguys.recruitment.repository.JobPostingRepo;
+import com.fallguys.recruitment.repository.ProjectPostingRepo;
+import com.fallguys.recruitment.service.port.RecruitmentUser;
+import com.fallguys.recruitment.service.port.RecruitmentUserReader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JobPostingServiceCoreTest {
+
+    @Mock
+    private JobPostingRepo jobPostingRepo;
+    @Mock
+    private JobPostingFavoriteRepo jobPostingFavoriteRepo;
+    @Mock
+    private ProjectPostingRepo projectPostingRepo;
+    @Mock
+    private RecruitmentUserReader recruitmentUserReader;
+    @Mock
+    private RecommendationEngine recommendationEngine;
+
+    @InjectMocks
+    private JobPostingServiceImpl service;
+
+    @Test
+    @DisplayName("[TDD] 채용공고 생성 시 고용주 정보로 저장된다")
+    void createJobPosting_savesByEmployer() {
+        // given
+        Long userId = 1L;
+        JobPostingCreateDTO request = new JobPostingCreateDTO("Backend", "desc", List.of("Java"), 1000L, 3, 2);
+        when(recruitmentUserReader.getEmployerByIdOrThrow(userId))
+                .thenReturn(new RecruitmentUser(userId, "employer", null, null, "ACTIVE"));
+
+        // when
+        service.createJobPosting(request, userId);
+
+        // then
+        ArgumentCaptor<JobPosting> captor = ArgumentCaptor.forClass(JobPosting.class);
+        verify(jobPostingRepo, times(1)).save(captor.capture());
+        assertEquals(userId, captor.getValue().getEmployerId());
+        assertEquals("employer", captor.getValue().getEmployerName());
+        assertEquals("Backend", captor.getValue().getTitle());
+    }
+
+    @Test
+    @DisplayName("[TDD] 채용공고 수정 시 소유자가 다르면 JOB_POSTING_FORBIDDEN 예외")
+    void updateJobPosting_forbiddenOwner_throws() {
+        // given
+        Long userId = 1L;
+        Long postingId = 10L;
+        JobPosting posting = posting(postingId, 99L, Status.ACTIVE);
+        when(recruitmentUserReader.getEmployerByIdOrThrow(userId))
+                .thenReturn(new RecruitmentUser(userId, "employer", null, null, "ACTIVE"));
+        when(jobPostingRepo.findById(postingId)).thenReturn(Optional.of(posting));
+
+        // when
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> service.updateJobPosting(new JobPostingUpdateDTO("new", null, null, null, null, null, null), postingId, userId)
+        );
+
+        // then
+        assertEquals(ErrorCode.JOB_POSTING_FORBIDDEN, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("[TDD] 채용공고 삭제 시 soft delete 된다")
+    void deleteJobPosting_softDelete() {
+        // given
+        Long userId = 1L;
+        Long postingId = 11L;
+        JobPosting posting = posting(postingId, userId, Status.ACTIVE);
+        when(recruitmentUserReader.getEmployerByIdOrThrow(userId))
+                .thenReturn(new RecruitmentUser(userId, "employer", null, null, "ACTIVE"));
+        when(jobPostingRepo.findById(postingId)).thenReturn(Optional.of(posting));
+
+        // when
+        service.deleteJobPosting(postingId, userId);
+
+        // then
+        assertEquals(Status.DELETED, posting.getStatus());
+    }
+
+    @Test
+    @DisplayName("[TDD] 추천 프리랜서 조회 시 공고 소유자가 다르면 JOB_POSTING_FORBIDDEN 예외")
+    void getRecommendedFreelancers_forbiddenOwner_throws() {
+        // given
+        Long userId = 1L;
+        Long postingId = 30L;
+        when(jobPostingRepo.findById(postingId)).thenReturn(Optional.of(posting(postingId, 99L, Status.ACTIVE)));
+
+        // when
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> service.getRecommendedFreelancers(postingId, userId)
+        );
+
+        // then
+        assertEquals(ErrorCode.JOB_POSTING_FORBIDDEN, ex.getErrorCode());
+        verify(recommendationEngine, never()).recommendFreelancers(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("[TDD] 프리랜서 추천공고 조회 시 skills/experience 공백은 '없음'으로 전달")
+    void getRecommendedJobsForFreelancer_blankProfile_usesDefaultText() {
+        // given
+        Long userId = 2L;
+        when(recruitmentUserReader.getFreelancerByIdOrThrow(userId))
+                .thenReturn(new RecruitmentUser(userId, "freelancer", "  ", null, "ACTIVE"));
+        when(recommendationEngine.recommendJobs(eq(userId), any(), any(), eq(AiRecommendationResponseDTO.class)))
+                .thenReturn(List.of());
+
+        // when
+        service.getRecommendedJobsForFreelancer(userId);
+
+        // then
+        verify(recommendationEngine, times(1))
+                .recommendJobs(userId, "없음", "없음", AiRecommendationResponseDTO.class);
+    }
+
+    @Test
+    @DisplayName("[TDD] 프로젝트 완료 시 이미 완료된 프로젝트면 PROJECT_ALREADY_COMPLETED 예외")
+    void completeProject_alreadyCompleted_throws() {
+        // given
+        Long projectId = 40L;
+        Long userId = 5L;
+        Project project = Project.create(posting(100L, userId, Status.ACTIVE), 77L);
+        ReflectionTestUtils.setField(project, "status", ProjectStatus.COMPLETED);
+        when(projectPostingRepo.findById(projectId)).thenReturn(Optional.of(project));
+
+        // when
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> service.completeProject(projectId, userId)
+        );
+
+        // then
+        assertEquals(ErrorCode.PROJECT_ALREADY_COMPLETED, ex.getErrorCode());
+    }
+
+    private JobPosting posting(Long id, Long employerId, Status status) {
+        JobPosting posting = JobPosting.from(
+                new JobPostingCreateDTO("title", "desc", List.of("Java"), 1000L, 3, 2),
+                employerId,
+                "employer"
+        );
+        ReflectionTestUtils.setField(posting, "id", id, Long.class);
+        ReflectionTestUtils.setField(posting, "status", status);
+        ReflectionTestUtils.setField(posting, "postingStatus", JobPostingStatus.OPEN);
+        return posting;
+    }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #미기재

## 📝 작업 내용
`recruitment` 모듈(`com.fallguys.recruitment`)에 대해 기존 즐겨찾기 테스트 외 핵심 로직 테스트를 추가했습니다.  
서비스 비즈니스 로직, 토큰 파싱 로직, 고용주/프리랜서 컨트롤러 요청 처리 흐름을 보강했습니다.

## ✅ Changes
- `recruitment/build.gradle` 테스트 의존성 추가
- `testImplementation 'io.jsonwebtoken:jjwt-api:0.13.0'` 추가
- `JobPostingServiceCoreTest` 추가
- 채용공고 생성 시 고용주 정보 매핑 저장 검증
- 채용공고 수정 시 소유자 불일치 `JOB_POSTING_FORBIDDEN` 예외 검증
- 채용공고 삭제 시 soft delete 검증
- 추천 프리랜서 조회 시 소유자 불일치 `JOB_POSTING_FORBIDDEN` 예외 검증
- 추천 공고 조회 시 freelancer `skills/experience` 공백 정규화(`없음`) 검증
- 프로젝트 완료 시 이미 완료된 프로젝트의 `PROJECT_ALREADY_COMPLETED` 예외 검증
- `TokenUserIdResolverTest` 추가
- Authorization 형식 오류 예외 검증
- `subject` 기반 userId 파싱 검증
- `id` claim fallback 파싱 검증
- `JobPostingEmployerControllerTest` 추가
- 공고 생성 API의 토큰 해석 → 서비스 호출 → `200 OK` 응답 검증
- 내 공고 조회 API의 페이지 보정(`page>=0`, `size>=1`) 및 페이징 응답 검증
- `JobPostingFreelancerControllerTest` 추가
- 공고 검색 API의 파라미터 전달/응답 검증
- 추천 공고 API의 토큰 해석/서비스 호출/응답 검증
- 테스트 실행 확인
- `:recruitment:test --tests ...` 결과 `BUILD SUCCESSFUL`

## 📸 스크린샷 (선택)
테스트 실행 콘솔/리포트 캡처 첨부 예정

## ⚠️ Notes (Optional)
- 이번 변경은 테스트 코드 및 테스트 의존성만 포함하며, 프로덕션 로직 변경은 없습니다.
- 이슈 번호 확정 후 `Closes #...`로 업데이트가 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * JWT 토큰 검증, 채용공고 생성 및 관리, 프리랜서 및 고용주 상호작용에 대한 종합적인 단위 테스트 추가
  * 일자리 추천 엔진 및 서비스 레이어 기능 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->