### PR TITLE
HFP-96 [feat] Redis Setting

### DIFF
--- a/freebridge/matchs/build.gradle
+++ b/freebridge/matchs/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation project(':recruitment') // 채용 공고 참조
     implementation project(':user')
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     compileOnly 'io.jsonwebtoken:jjwt-api:0.13.0'
     testImplementation 'io.jsonwebtoken:jjwt-api:0.13.0'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui'

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ApplicationRepo.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ApplicationRepo.java
@@ -5,8 +5,16 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ApplicationRepo extends JpaRepository<Application,Long> {
     Page<Application> findAllByEmployerIdOrderByCreatedAtDesc(Long employerId, Pageable pageable);
 
     Page<Application> findAllByFreelancerIdOrderByCreatedAtDesc(Long freelancerId, Pageable pageable);
+
+    List<Application> findAllByFreelancerIdOrderByCreatedAtDesc(Long freelancerId);
+
+    List<Application> findAllByJobPostingIdOrderByCreatedAtDesc(Long jobPostingId);
+
+    long countByJobPostingId(Long jobPostingId);
 }

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ApplicationRepo.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ApplicationRepo.java
@@ -1,6 +1,7 @@
 package com.fallguys.matchs.repository;
 
 import com.fallguys.matchs.entity.Application;
+import com.fallguys.matchs.entity.MatchsStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface ApplicationRepo extends JpaRepository<Application,Long> {
     Page<Application> findAllByEmployerIdOrderByCreatedAtDesc(Long employerId, Pageable pageable);
@@ -29,8 +31,22 @@ public interface ApplicationRepo extends JpaRepository<Application,Long> {
             """)
     List<JobPostingApplicantCountProjection> countApplicantsByJobPostingIds(@Param("jobPostingIds") Collection<Long> jobPostingIds);
 
+    @Query("""
+            select a.id as applicationId, a.jobPostingId as jobPostingId, a.freelancerId as freelancerId, a.status as status
+            from Application a
+            where a.id = :applicationId
+            """)
+    Optional<ApplicantStatusProjection> findApplicantStatusProjectionById(@Param("applicationId") Long applicationId);
+
     interface JobPostingApplicantCountProjection {
         Long getJobPostingId();
         Long getApplicantCount();
+    }
+
+    interface ApplicantStatusProjection {
+        Long getApplicationId();
+        Long getJobPostingId();
+        Long getFreelancerId();
+        MatchsStatus getStatus();
     }
 }

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ApplicationRepo.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ApplicationRepo.java
@@ -23,6 +23,8 @@ public interface ApplicationRepo extends JpaRepository<Application,Long> {
 
     long countByJobPostingId(Long jobPostingId);
 
+    long countByFreelancerId(Long freelancerId);
+
     @Query("""
             select a.jobPostingId as jobPostingId, count(a.id) as applicantCount
             from Application a

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ApplicationRepo.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ApplicationRepo.java
@@ -4,7 +4,10 @@ import com.fallguys.matchs.entity.Application;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface ApplicationRepo extends JpaRepository<Application,Long> {
@@ -17,4 +20,17 @@ public interface ApplicationRepo extends JpaRepository<Application,Long> {
     List<Application> findAllByJobPostingIdOrderByCreatedAtDesc(Long jobPostingId);
 
     long countByJobPostingId(Long jobPostingId);
+
+    @Query("""
+            select a.jobPostingId as jobPostingId, count(a.id) as applicantCount
+            from Application a
+            where a.jobPostingId in :jobPostingIds
+            group by a.jobPostingId
+            """)
+    List<JobPostingApplicantCountProjection> countApplicantsByJobPostingIds(@Param("jobPostingIds") Collection<Long> jobPostingIds);
+
+    interface JobPostingApplicantCountProjection {
+        Long getJobPostingId();
+        Long getApplicantCount();
+    }
 }

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ApplicationRepo.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ApplicationRepo.java
@@ -17,8 +17,6 @@ public interface ApplicationRepo extends JpaRepository<Application,Long> {
 
     Page<Application> findAllByFreelancerIdOrderByCreatedAtDesc(Long freelancerId, Pageable pageable);
 
-    List<Application> findAllByFreelancerIdOrderByCreatedAtDesc(Long freelancerId);
-
     List<Application> findAllByJobPostingIdOrderByCreatedAtDesc(Long jobPostingId);
 
     long countByJobPostingId(Long jobPostingId);

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ProposalRepo.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ProposalRepo.java
@@ -12,7 +12,5 @@ public interface ProposalRepo extends JpaRepository<Proposal,Long> {
 
     Page<Proposal> findAllByFreelancerIdOrderByCreatedAtDesc(Long freelancerId, Pageable pageable);
 
-    List<Proposal> findAllByFreelancerIdOrderByCreatedAtDesc(Long freelancerId);
-
     long countByFreelancerId(Long freelancerId);
 }

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ProposalRepo.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ProposalRepo.java
@@ -5,8 +5,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ProposalRepo extends JpaRepository<Proposal,Long> {
     Page<Proposal> findAllByEmployerIdOrderByCreatedAtDesc(Long employerId, Pageable pageable);
 
     Page<Proposal> findAllByFreelancerIdOrderByCreatedAtDesc(Long freelancerId, Pageable pageable);
+
+    List<Proposal> findAllByFreelancerIdOrderByCreatedAtDesc(Long freelancerId);
 }

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ProposalRepo.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ProposalRepo.java
@@ -13,4 +13,6 @@ public interface ProposalRepo extends JpaRepository<Proposal,Long> {
     Page<Proposal> findAllByFreelancerIdOrderByCreatedAtDesc(Long freelancerId, Pageable pageable);
 
     List<Proposal> findAllByFreelancerIdOrderByCreatedAtDesc(Long freelancerId);
+
+    long countByFreelancerId(Long freelancerId);
 }

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
@@ -57,6 +57,7 @@ public class MatchsServiceImpl implements MatchsService {
     private static final String FREELANCER_PROJECT_APPLIED_KEY_PREFIX = "freelancer:project:applied:";
     private static final DateTimeFormatter ISO_SECONDS_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
     private static final int FREELANCER_APPLIED_CACHE_LIMIT = 100;
+    private static final int APPLICANT_COUNT_QUERY_CHUNK_SIZE = 500;
 
     private final ApplicationRepo applicationRepo;
     private final ProposalRepo proposalRepo;
@@ -411,21 +412,7 @@ public class MatchsServiceImpl implements MatchsService {
                 .map(JobPosting::getId)
                 .filter(Objects::nonNull)
                 .toList();
-        Map<Long, Integer> applicantCountsByPostingId = new HashMap<>();
-        if (!postingIds.isEmpty()) {
-            orEmpty(applicationRepo.countApplicantsByJobPostingIds(postingIds))
-                    .forEach(result -> {
-                        Long jobPostingId = result.getJobPostingId();
-                        if (jobPostingId == null) {
-                            return;
-                        }
-                        Long applicantCount = result.getApplicantCount();
-                        applicantCountsByPostingId.put(
-                                jobPostingId,
-                                applicantCount == null ? 0 : Math.toIntExact(applicantCount)
-                        );
-                    });
-        }
+        Map<Long, Integer> applicantCountsByPostingId = loadApplicantCountsByPostingIds(postingIds);
 
         List<Map<String, Object>> payload = new ArrayList<>(postings.size());
         for (JobPosting posting : postings) {
@@ -445,6 +432,29 @@ public class MatchsServiceImpl implements MatchsService {
         }
 
         writeRedisValue(EMPLOYER_PROJECT_LIST_KEY_PREFIX + employerId, payload);
+    }
+
+    private Map<Long, Integer> loadApplicantCountsByPostingIds(List<Long> postingIds) {
+        Map<Long, Integer> countsByPostingId = new HashMap<>();
+        if (postingIds.isEmpty()) {
+            return countsByPostingId;
+        }
+
+        for (int start = 0; start < postingIds.size(); start += APPLICANT_COUNT_QUERY_CHUNK_SIZE) {
+            int end = Math.min(start + APPLICANT_COUNT_QUERY_CHUNK_SIZE, postingIds.size());
+            List<Long> chunk = postingIds.subList(start, end);
+            orEmpty(applicationRepo.countApplicantsByJobPostingIds(chunk))
+                    .forEach(result -> {
+                        Long jobPostingId = result.getJobPostingId();
+                        if (jobPostingId == null) {
+                            return;
+                        }
+                        Long applicantCount = result.getApplicantCount();
+                        int normalizedCount = applicantCount == null ? 0 : Math.toIntExact(applicantCount);
+                        countsByPostingId.merge(jobPostingId, normalizedCount, Integer::sum);
+                    });
+        }
+        return countsByPostingId;
     }
 
     private void refreshEmployerProjectApplicants(Long applicationId) {

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
@@ -12,7 +12,9 @@ import com.fallguys.matchs.entity.Proposal;
 import com.fallguys.matchs.repository.ApplicationRepo;
 import com.fallguys.matchs.repository.ProposalRepo;
 import com.fallguys.recruitment.entity.JobPosting;
+import com.fallguys.recruitment.entity.JobPostingStatus;
 import com.fallguys.recruitment.entity.Project;
+import com.fallguys.recruitment.entity.ProjectStatus;
 import com.fallguys.recruitment.entity.Status;
 import com.fallguys.recruitment.repository.JobPostingRepo;
 import com.fallguys.recruitment.repository.ProjectPostingRepo;
@@ -20,21 +22,46 @@ import com.fallguys.user.entity.Role;
 import com.fallguys.user.entity.User;
 import com.fallguys.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MatchsServiceImpl implements MatchsService {
+
+    private static final String EMPLOYER_PROJECT_STATS_KEY_PREFIX = "employer:project:stats:";
+    private static final String EMPLOYER_PROJECT_LIST_KEY_PREFIX = "employer:project:list:";
+    private static final String EMPLOYER_PROJECT_APPLICANTS_KEY_PREFIX = "employer:project:applicants:";
+    private static final String FREELANCER_PROJECT_STATS_KEY_PREFIX = "freelancer:project:stats:";
+    private static final String FREELANCER_PROJECT_APPLIED_KEY_PREFIX = "freelancer:project:applied:";
+    private static final DateTimeFormatter ISO_SECONDS_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
     private final ApplicationRepo applicationRepo;
     private final ProposalRepo proposalRepo;
     private final JobPostingRepo jobPostingRepo;
     private final ProjectPostingRepo projectPostingRepo;
     private final UserRepository userRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
     @Transactional
@@ -49,7 +76,15 @@ public class MatchsServiceImpl implements MatchsService {
                 request.message()
         );
 
-        return applicationRepo.save(application).getId();
+        Long applicationId = applicationRepo.save(application).getId();
+        runAfterCommitSafely(() -> {
+            refreshEmployerProjectStats(jobPosting.getEmployerId());
+            refreshEmployerProjectList(jobPosting.getEmployerId());
+            refreshEmployerProjectApplicants(jobPosting.getId());
+            refreshFreelancerProjectStats(freelancerId);
+            refreshFreelancerAppliedProjects(freelancerId);
+        });
+        return applicationId;
     }
 
     @Override
@@ -70,7 +105,14 @@ public class MatchsServiceImpl implements MatchsService {
                 request.message()
         );
 
-        return proposalRepo.save(proposal).getId();
+        Long proposalId = proposalRepo.save(proposal).getId();
+        runAfterCommitSafely(() -> {
+            refreshEmployerProjectStats(employerId);
+            refreshEmployerProjectList(employerId);
+            refreshFreelancerProjectStats(request.freelancerId());
+            refreshFreelancerAppliedProjects(request.freelancerId());
+        });
+        return proposalId;
     }
 
     @Override
@@ -83,7 +125,15 @@ public class MatchsServiceImpl implements MatchsService {
         validatePending(application.getStatus());
 
         application.accept();
-        return createProjectIfAbsent(application.getJobPostingId(), application.getFreelancerId());
+        Long projectId = createProjectIfAbsent(application.getJobPostingId(), application.getFreelancerId());
+        runAfterCommitSafely(() -> {
+            refreshEmployerProjectStats(application.getEmployerId());
+            refreshEmployerProjectList(application.getEmployerId());
+            refreshEmployerProjectApplicants(application.getJobPostingId());
+            refreshFreelancerProjectStats(application.getFreelancerId());
+            refreshFreelancerAppliedProjects(application.getFreelancerId());
+        });
+        return projectId;
     }
 
     @Override
@@ -96,7 +146,15 @@ public class MatchsServiceImpl implements MatchsService {
         validatePending(proposal.getStatus());
 
         proposal.accept();
-        return createProjectIfAbsent(proposal.getJobPostingId(), freelancerId);
+        Long projectId = createProjectIfAbsent(proposal.getJobPostingId(), freelancerId);
+        runAfterCommitSafely(() -> {
+            refreshEmployerProjectStats(proposal.getEmployerId());
+            refreshEmployerProjectList(proposal.getEmployerId());
+            refreshEmployerProjectApplicants(proposal.getJobPostingId());
+            refreshFreelancerProjectStats(freelancerId);
+            refreshFreelancerAppliedProjects(freelancerId);
+        });
+        return projectId;
     }
 
     @Override
@@ -109,6 +167,13 @@ public class MatchsServiceImpl implements MatchsService {
         validatePending(application.getStatus());
 
         application.reject();
+        runAfterCommitSafely(() -> {
+            refreshEmployerProjectStats(application.getEmployerId());
+            refreshEmployerProjectList(application.getEmployerId());
+            refreshEmployerProjectApplicants(application.getJobPostingId());
+            refreshFreelancerProjectStats(application.getFreelancerId());
+            refreshFreelancerAppliedProjects(application.getFreelancerId());
+        });
         return application.getId();
     }
 
@@ -122,6 +187,12 @@ public class MatchsServiceImpl implements MatchsService {
         validatePending(proposal.getStatus());
 
         proposal.reject();
+        runAfterCommitSafely(() -> {
+            refreshEmployerProjectStats(proposal.getEmployerId());
+            refreshEmployerProjectList(proposal.getEmployerId());
+            refreshFreelancerProjectStats(freelancerId);
+            refreshFreelancerAppliedProjects(freelancerId);
+        });
         return proposal.getId();
     }
 
@@ -283,5 +354,221 @@ public class MatchsServiceImpl implements MatchsService {
                 proposal.getStatus(),
                 proposal.getCreatedAt()
         );
+    }
+
+    private void runAfterCommit(Runnable task) {
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    task.run();
+                }
+            });
+            return;
+        }
+        task.run();
+    }
+
+    private void runAfterCommitSafely(Runnable task) {
+        runAfterCommit(() -> {
+            try {
+                task.run();
+            } catch (RuntimeException e) {
+                log.warn("Failed to refresh mypage redis payload after commit", e);
+            }
+        });
+    }
+
+    private void refreshEmployerProjectStats(Long employerId) {
+        List<JobPosting> postings = orEmpty(jobPostingRepo.findAllByEmployerIdAndStatusNot(employerId, Status.DELETED));
+        List<Project> projects = orEmpty(projectPostingRepo.findAllByEmployerIdOrderByCreatedAtDesc(employerId));
+
+        int activeApplicants = (int) projects.stream()
+                .filter(project -> project.getStatus() == ProjectStatus.IN_PROGRESS)
+                .count();
+        int contractedFreelancers = (int) projects.stream()
+                .map(Project::getFreelancerId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .count();
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("totalProjects", postings.size());
+        payload.put("activeApplicants", activeApplicants);
+        payload.put("contractedFreelancers", contractedFreelancers);
+
+        writeRedisValue(EMPLOYER_PROJECT_STATS_KEY_PREFIX + employerId, payload);
+    }
+
+    private void refreshEmployerProjectList(Long employerId) {
+        List<JobPosting> postings = orEmpty(jobPostingRepo.findAllByEmployerIdAndStatusNot(employerId, Status.DELETED))
+                .stream()
+                .sorted(Comparator.comparing(JobPosting::getCreatedAt).reversed())
+                .toList();
+
+        List<Map<String, Object>> payload = new ArrayList<>(postings.size());
+        for (JobPosting posting : postings) {
+            Map<String, Object> item = new HashMap<>();
+            item.put("projectId", posting.getId());
+            item.put("title", posting.getTitle());
+            item.put("status", toEmployerProjectStatus(posting.getPostingStatus()));
+            item.put("applicantCount", Math.toIntExact(applicationRepo.countByJobPostingId(posting.getId())));
+            item.put("createdAt", formatIsoSeconds(posting.getCreatedAt()));
+
+            LocalDateTime deadline = posting.getCreatedAt();
+            if (posting.getDuration() != null && posting.getDuration() > 0) {
+                deadline = deadline.plusDays(posting.getDuration());
+            }
+            item.put("deadline", formatIsoSeconds(deadline));
+            payload.add(item);
+        }
+
+        writeRedisValue(EMPLOYER_PROJECT_LIST_KEY_PREFIX + employerId, payload);
+    }
+
+    private void refreshEmployerProjectApplicants(Long projectId) {
+        List<Map<String, Object>> payload = orEmpty(applicationRepo.findAllByJobPostingIdOrderByCreatedAtDesc(projectId))
+                .stream()
+                .map(application -> {
+                    Map<String, Object> item = new HashMap<>();
+                    item.put("freelancerId", application.getFreelancerId());
+                    item.put("applyStatus", toEmployerApplicantStatus(application.getStatus()));
+                    return item;
+                })
+                .toList();
+
+        writeRedisValue(EMPLOYER_PROJECT_APPLICANTS_KEY_PREFIX + projectId, payload);
+    }
+
+    private void refreshFreelancerProjectStats(Long freelancerId) {
+        int appliedProjects = orEmpty(applicationRepo.findAllByFreelancerIdOrderByCreatedAtDesc(freelancerId)).size()
+                + orEmpty(proposalRepo.findAllByFreelancerIdOrderByCreatedAtDesc(freelancerId)).size();
+
+        List<Project> projects = orEmpty(projectPostingRepo.findAllByFreelancerIdOrderByCreatedAtDesc(freelancerId));
+        int inProgressProjects = (int) projects.stream()
+                .filter(project -> project.getStatus() == ProjectStatus.IN_PROGRESS)
+                .count();
+        int completedProjects = (int) projects.stream()
+                .filter(project -> project.getStatus() == ProjectStatus.COMPLETED)
+                .count();
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("appliedProjects", appliedProjects);
+        payload.put("inProgressProjects", inProgressProjects);
+        payload.put("completedProjects", completedProjects);
+
+        writeRedisValue(FREELANCER_PROJECT_STATS_KEY_PREFIX + freelancerId, payload);
+    }
+
+    private void refreshFreelancerAppliedProjects(Long freelancerId) {
+        List<Application> applications = orEmpty(applicationRepo.findAllByFreelancerIdOrderByCreatedAtDesc(freelancerId));
+        List<Proposal> proposals = orEmpty(proposalRepo.findAllByFreelancerIdOrderByCreatedAtDesc(freelancerId));
+
+        Set<Long> postingIds = new LinkedHashSet<>();
+        applications.stream().map(Application::getJobPostingId).forEach(postingIds::add);
+        proposals.stream().map(Proposal::getJobPostingId).forEach(postingIds::add);
+
+        Map<Long, JobPosting> postingsById = new HashMap<>();
+        if (!postingIds.isEmpty()) {
+            jobPostingRepo.findAllById(postingIds).forEach(posting -> postingsById.put(posting.getId(), posting));
+        }
+
+        List<Map<String, Object>> payload = new ArrayList<>();
+        for (Application application : applications) {
+            JobPosting posting = postingsById.get(application.getJobPostingId());
+            payload.add(toFreelancerAppliedItem(
+                    application.getJobPostingId(),
+                    posting,
+                    toFreelancerApplyStatus(application.getStatus()),
+                    application.getCreatedAt()
+            ));
+        }
+        for (Proposal proposal : proposals) {
+            JobPosting posting = postingsById.get(proposal.getJobPostingId());
+            payload.add(toFreelancerAppliedItem(
+                    proposal.getJobPostingId(),
+                    posting,
+                    toFreelancerApplyStatus(proposal.getStatus()),
+                    proposal.getCreatedAt()
+            ));
+        }
+
+        payload.sort(Comparator.comparingLong(item -> (Long) item.get("appliedAt")));
+        java.util.Collections.reverse(payload);
+
+        writeRedisValue(FREELANCER_PROJECT_APPLIED_KEY_PREFIX + freelancerId, payload);
+    }
+
+    private Map<String, Object> toFreelancerAppliedItem(Long projectId, JobPosting posting, String applyStatus, LocalDateTime appliedAt) {
+        Map<String, Object> item = new HashMap<>();
+        item.put("projectId", projectId);
+        item.put("title", posting != null ? posting.getTitle() : null);
+        item.put("employerName", posting != null ? posting.getEmployerName() : null);
+        item.put("applyStatus", applyStatus);
+        item.put("appliedAt", toEpochMillis(appliedAt));
+        return item;
+    }
+
+    private String toEmployerProjectStatus(JobPostingStatus status) {
+        if (status == null) {
+            return "모집중";
+        }
+        return switch (status) {
+            case OPEN -> "모집중";
+            case IN_PROGRESS -> "진행중";
+            case COMPLETED -> "완료";
+            case CLOSED -> "마감";
+        };
+    }
+
+    private String toEmployerApplicantStatus(MatchsStatus status) {
+        if (status == null) {
+            return "검토중";
+        }
+        return switch (status) {
+            case PENDING -> "검토중";
+            case ACCEPTED -> "합격";
+            case REJECTED -> "거절";
+        };
+    }
+
+    private String toFreelancerApplyStatus(MatchsStatus status) {
+        if (status == null) {
+            return "심사중";
+        }
+        return switch (status) {
+            case PENDING -> "심사중";
+            case ACCEPTED -> "합격";
+            case REJECTED -> "거절";
+        };
+    }
+
+    private String formatIsoSeconds(LocalDateTime dateTime) {
+        if (dateTime == null) {
+            return null;
+        }
+        return dateTime.format(ISO_SECONDS_FORMATTER);
+    }
+
+    private long toEpochMillis(LocalDateTime dateTime) {
+        if (dateTime == null) {
+            return 0L;
+        }
+        return dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+    }
+
+    private void writeRedisValue(String key, Object value) {
+        if (redisTemplate == null) {
+            return;
+        }
+        try {
+            redisTemplate.opsForValue().set(key, value);
+        } catch (RuntimeException e) {
+            log.warn("Failed to write mypage redis payload. key={}", key, e);
+        }
+    }
+
+    private <T> List<T> orEmpty(List<T> list) {
+        return list == null ? List.of() : list;
     }
 }

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
@@ -80,7 +80,7 @@ public class MatchsServiceImpl implements MatchsService {
         runAfterCommitSafely(() -> {
             refreshEmployerProjectStats(jobPosting.getEmployerId());
             refreshEmployerProjectList(jobPosting.getEmployerId());
-            refreshEmployerProjectApplicants(jobPosting.getId());
+            refreshEmployerProjectApplicants(applicationId);
             refreshFreelancerProjectStats(freelancerId);
             refreshFreelancerAppliedProjects(freelancerId);
         });
@@ -129,7 +129,7 @@ public class MatchsServiceImpl implements MatchsService {
         runAfterCommitSafely(() -> {
             refreshEmployerProjectStats(application.getEmployerId());
             refreshEmployerProjectList(application.getEmployerId());
-            refreshEmployerProjectApplicants(application.getJobPostingId());
+            refreshEmployerProjectApplicants(application.getId());
             refreshFreelancerProjectStats(application.getFreelancerId());
             refreshFreelancerAppliedProjects(application.getFreelancerId());
         });
@@ -150,7 +150,6 @@ public class MatchsServiceImpl implements MatchsService {
         runAfterCommitSafely(() -> {
             refreshEmployerProjectStats(proposal.getEmployerId());
             refreshEmployerProjectList(proposal.getEmployerId());
-            refreshEmployerProjectApplicants(proposal.getJobPostingId());
             refreshFreelancerProjectStats(freelancerId);
             refreshFreelancerAppliedProjects(freelancerId);
         });
@@ -170,7 +169,7 @@ public class MatchsServiceImpl implements MatchsService {
         runAfterCommitSafely(() -> {
             refreshEmployerProjectStats(application.getEmployerId());
             refreshEmployerProjectList(application.getEmployerId());
-            refreshEmployerProjectApplicants(application.getJobPostingId());
+            refreshEmployerProjectApplicants(application.getId());
             refreshFreelancerProjectStats(application.getFreelancerId());
             refreshFreelancerAppliedProjects(application.getFreelancerId());
         });
@@ -446,18 +445,68 @@ public class MatchsServiceImpl implements MatchsService {
         writeRedisValue(EMPLOYER_PROJECT_LIST_KEY_PREFIX + employerId, payload);
     }
 
-    private void refreshEmployerProjectApplicants(Long projectId) {
-        List<Map<String, Object>> payload = orEmpty(applicationRepo.findAllByJobPostingIdOrderByCreatedAtDesc(projectId))
-                .stream()
-                .map(application -> {
-                    Map<String, Object> item = new HashMap<>();
-                    item.put("freelancerId", application.getFreelancerId());
-                    item.put("applyStatus", toEmployerApplicantStatus(application.getStatus()));
-                    return item;
-                })
-                .toList();
+    private void refreshEmployerProjectApplicants(Long applicationId) {
+        applicationRepo.findApplicantStatusProjectionById(applicationId)
+                .ifPresent(this::upsertEmployerProjectApplicant);
+    }
 
-        writeRedisValue(EMPLOYER_PROJECT_APPLICANTS_KEY_PREFIX + projectId, payload);
+    private void upsertEmployerProjectApplicant(ApplicationRepo.ApplicantStatusProjection applicant) {
+        Long projectId = applicant.getJobPostingId();
+        Long freelancerId = applicant.getFreelancerId();
+        if (projectId == null || freelancerId == null) {
+            return;
+        }
+
+        String redisKey = EMPLOYER_PROJECT_APPLICANTS_KEY_PREFIX + projectId;
+        List<Map<String, Object>> payload = readEmployerProjectApplicantsPayload(redisKey);
+
+        Map<String, Object> updatedItem = new HashMap<>();
+        updatedItem.put("freelancerId", freelancerId);
+        updatedItem.put("applyStatus", toEmployerApplicantStatus(applicant.getStatus()));
+
+        boolean updated = false;
+        for (int i = 0; i < payload.size(); i++) {
+            Map<String, Object> current = payload.get(i);
+            if (current == null) {
+                continue;
+            }
+            Object currentFreelancerId = current.get("freelancerId");
+            if (currentFreelancerId == null) {
+                continue;
+            }
+            if (freelancerId.equals(parseLongSafely(currentFreelancerId))) {
+                payload.set(i, updatedItem);
+                updated = true;
+                break;
+            }
+        }
+
+        if (!updated) {
+            payload.add(0, updatedItem);
+        }
+
+        writeRedisValue(redisKey, payload);
+    }
+
+    private List<Map<String, Object>> readEmployerProjectApplicantsPayload(String redisKey) {
+        try {
+            Object raw = redisTemplate.opsForValue().get(redisKey);
+            if (!(raw instanceof List<?> list)) {
+                return new ArrayList<>();
+            }
+            List<Map<String, Object>> payload = new ArrayList<>(list.size());
+            for (Object entry : list) {
+                if (entry instanceof Map<?, ?> rawMap) {
+                    Map<String, Object> item = new HashMap<>();
+                    rawMap.forEach((key, value) -> item.put(String.valueOf(key), value));
+                    payload.add(item);
+                }
+            }
+            return payload;
+        } catch (RuntimeException e) {
+            log.warn("Failed to read employer project applicants payload. key={}", redisKey, e);
+            return new ArrayList<>();
+        }
     }
 
     private void refreshFreelancerProjectStats(Long freelancerId) {
@@ -575,6 +624,20 @@ public class MatchsServiceImpl implements MatchsService {
             return 0L;
         }
         return dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+    }
+
+    private Long parseLongSafely(Object value) {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        if (value != null) {
+            try {
+                return Long.parseLong(value.toString());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
     }
 
     private void writeRedisValue(String key, Object value) {

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
@@ -510,16 +510,16 @@ public class MatchsServiceImpl implements MatchsService {
     }
 
     private void refreshFreelancerProjectStats(Long freelancerId) {
-        int appliedProjects = orEmpty(applicationRepo.findAllByFreelancerIdOrderByCreatedAtDesc(freelancerId)).size()
-                + orEmpty(proposalRepo.findAllByFreelancerIdOrderByCreatedAtDesc(freelancerId)).size();
-
-        List<Project> projects = orEmpty(projectPostingRepo.findAllByFreelancerIdOrderByCreatedAtDesc(freelancerId));
-        int inProgressProjects = (int) projects.stream()
-                .filter(project -> project.getStatus() == ProjectStatus.IN_PROGRESS)
-                .count();
-        int completedProjects = (int) projects.stream()
-                .filter(project -> project.getStatus() == ProjectStatus.COMPLETED)
-                .count();
+        int appliedProjects = Math.toIntExact(
+                applicationRepo.countByFreelancerId(freelancerId)
+                        + proposalRepo.countByFreelancerId(freelancerId)
+        );
+        int inProgressProjects = Math.toIntExact(
+                projectPostingRepo.countByFreelancerIdAndStatus(freelancerId, ProjectStatus.IN_PROGRESS)
+        );
+        int completedProjects = Math.toIntExact(
+                projectPostingRepo.countByFreelancerIdAndStatus(freelancerId, ProjectStatus.COMPLETED)
+        );
 
         Map<String, Object> payload = new HashMap<>();
         payload.put("appliedProjects", appliedProjects);

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
@@ -18,6 +18,7 @@ import com.fallguys.recruitment.entity.ProjectStatus;
 import com.fallguys.recruitment.entity.Status;
 import com.fallguys.recruitment.repository.JobPostingRepo;
 import com.fallguys.recruitment.repository.ProjectPostingRepo;
+import com.fallguys.recruitment.service.JobPostingService;
 import com.fallguys.user.entity.Role;
 import com.fallguys.user.entity.User;
 import com.fallguys.user.repository.UserRepository;
@@ -50,7 +51,6 @@ import java.util.Set;
 @Transactional(readOnly = true)
 public class MatchsServiceImpl implements MatchsService {
 
-    private static final String EMPLOYER_PROJECT_STATS_KEY_PREFIX = "employer:project:stats:";
     private static final String EMPLOYER_PROJECT_LIST_KEY_PREFIX = "employer:project:list:";
     private static final String EMPLOYER_PROJECT_APPLICANTS_KEY_PREFIX = "employer:project:applicants:";
     private static final String FREELANCER_PROJECT_STATS_KEY_PREFIX = "freelancer:project:stats:";
@@ -63,6 +63,7 @@ public class MatchsServiceImpl implements MatchsService {
     private final ProposalRepo proposalRepo;
     private final JobPostingRepo jobPostingRepo;
     private final ProjectPostingRepo projectPostingRepo;
+    private final JobPostingService jobPostingService;
     private final UserRepository userRepository;
     private final RedisTemplate<String, Object> redisTemplate;
 
@@ -382,24 +383,7 @@ public class MatchsServiceImpl implements MatchsService {
     }
 
     private void refreshEmployerProjectStats(Long employerId) {
-        List<JobPosting> postings = orEmpty(jobPostingRepo.findAllByEmployerIdAndStatusNot(employerId, Status.DELETED));
-        List<Project> projects = orEmpty(projectPostingRepo.findAllByEmployerIdOrderByCreatedAtDesc(employerId));
-
-        int activeApplicants = (int) projects.stream()
-                .filter(project -> project.getStatus() == ProjectStatus.IN_PROGRESS)
-                .count();
-        int contractedFreelancers = (int) projects.stream()
-                .map(Project::getFreelancerId)
-                .filter(Objects::nonNull)
-                .distinct()
-                .count();
-
-        Map<String, Object> payload = new HashMap<>();
-        payload.put("totalProjects", postings.size());
-        payload.put("activeApplicants", activeApplicants);
-        payload.put("contractedFreelancers", contractedFreelancers);
-
-        writeRedisValue(EMPLOYER_PROJECT_STATS_KEY_PREFIX + employerId, payload);
+        jobPostingService.refreshEmployerProjectStatsCache(employerId);
     }
 
     private void refreshEmployerProjectList(Long employerId) {

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
@@ -24,6 +24,7 @@ import com.fallguys.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -55,6 +56,7 @@ public class MatchsServiceImpl implements MatchsService {
     private static final String FREELANCER_PROJECT_STATS_KEY_PREFIX = "freelancer:project:stats:";
     private static final String FREELANCER_PROJECT_APPLIED_KEY_PREFIX = "freelancer:project:applied:";
     private static final DateTimeFormatter ISO_SECONDS_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+    private static final int FREELANCER_APPLIED_CACHE_LIMIT = 100;
 
     private final ApplicationRepo applicationRepo;
     private final ProposalRepo proposalRepo;
@@ -530,8 +532,13 @@ public class MatchsServiceImpl implements MatchsService {
     }
 
     private void refreshFreelancerAppliedProjects(Long freelancerId) {
-        List<Application> applications = orEmpty(applicationRepo.findAllByFreelancerIdOrderByCreatedAtDesc(freelancerId));
-        List<Proposal> proposals = orEmpty(proposalRepo.findAllByFreelancerIdOrderByCreatedAtDesc(freelancerId));
+        Pageable limitPageable = PageRequest.of(0, FREELANCER_APPLIED_CACHE_LIMIT);
+        List<Application> applications = orEmpty(
+                applicationRepo.findAllByFreelancerIdOrderByCreatedAtDesc(freelancerId, limitPageable).getContent()
+        );
+        List<Proposal> proposals = orEmpty(
+                proposalRepo.findAllByFreelancerIdOrderByCreatedAtDesc(freelancerId, limitPageable).getContent()
+        );
 
         Set<Long> postingIds = new LinkedHashSet<>();
         applications.stream().map(Application::getJobPostingId).forEach(postingIds::add);
@@ -564,6 +571,9 @@ public class MatchsServiceImpl implements MatchsService {
 
         payload.sort(Comparator.comparingLong(item -> (Long) item.get("appliedAt")));
         java.util.Collections.reverse(payload);
+        if (payload.size() > FREELANCER_APPLIED_CACHE_LIMIT) {
+            payload = new ArrayList<>(payload.subList(0, FREELANCER_APPLIED_CACHE_LIMIT));
+        }
 
         writeRedisValue(FREELANCER_PROJECT_APPLIED_KEY_PREFIX + freelancerId, payload);
     }

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
@@ -406,13 +406,33 @@ public class MatchsServiceImpl implements MatchsService {
                 .sorted(Comparator.comparing(JobPosting::getCreatedAt).reversed())
                 .toList();
 
+        List<Long> postingIds = postings.stream()
+                .map(JobPosting::getId)
+                .filter(Objects::nonNull)
+                .toList();
+        Map<Long, Integer> applicantCountsByPostingId = new HashMap<>();
+        if (!postingIds.isEmpty()) {
+            orEmpty(applicationRepo.countApplicantsByJobPostingIds(postingIds))
+                    .forEach(result -> {
+                        Long jobPostingId = result.getJobPostingId();
+                        if (jobPostingId == null) {
+                            return;
+                        }
+                        Long applicantCount = result.getApplicantCount();
+                        applicantCountsByPostingId.put(
+                                jobPostingId,
+                                applicantCount == null ? 0 : Math.toIntExact(applicantCount)
+                        );
+                    });
+        }
+
         List<Map<String, Object>> payload = new ArrayList<>(postings.size());
         for (JobPosting posting : postings) {
             Map<String, Object> item = new HashMap<>();
             item.put("projectId", posting.getId());
             item.put("title", posting.getTitle());
             item.put("status", toEmployerProjectStatus(posting.getPostingStatus()));
-            item.put("applicantCount", Math.toIntExact(applicationRepo.countByJobPostingId(posting.getId())));
+            item.put("applicantCount", applicantCountsByPostingId.getOrDefault(posting.getId(), 0));
             item.put("createdAt", formatIsoSeconds(posting.getCreatedAt()));
 
             LocalDateTime deadline = posting.getCreatedAt();

--- a/freebridge/matchs/src/test/java/com/fallguys/matchs/service/MatchsServiceImplTest.java
+++ b/freebridge/matchs/src/test/java/com/fallguys/matchs/service/MatchsServiceImplTest.java
@@ -15,6 +15,7 @@ import com.fallguys.recruitment.entity.Project;
 import com.fallguys.recruitment.entity.Status;
 import com.fallguys.recruitment.repository.JobPostingRepo;
 import com.fallguys.recruitment.repository.ProjectPostingRepo;
+import com.fallguys.recruitment.service.JobPostingService;
 import com.fallguys.user.entity.Role;
 import com.fallguys.user.entity.User;
 import com.fallguys.user.repository.UserRepository;
@@ -50,6 +51,8 @@ class MatchsServiceImplTest {
     private ProjectPostingRepo projectPostingRepo;
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private JobPostingService jobPostingService;
 
     @InjectMocks
     private MatchsServiceImpl matchsService;

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/repository/ProjectPostingRepo.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/repository/ProjectPostingRepo.java
@@ -1,6 +1,7 @@
 package com.fallguys.recruitment.repository;
 
 import com.fallguys.recruitment.entity.Project;
+import com.fallguys.recruitment.entity.ProjectStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -16,4 +17,6 @@ public interface ProjectPostingRepo extends JpaRepository<Project, Long> {
     List<Project> findAllByEmployerIdOrderByCreatedAtDesc(Long employerId);
 
     List<Project> findAllByFreelancerIdOrderByCreatedAtDesc(Long freelancerId);
+
+    long countByFreelancerIdAndStatus(Long freelancerId, ProjectStatus status);
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/repository/ProjectPostingRepo.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/repository/ProjectPostingRepo.java
@@ -14,4 +14,6 @@ public interface ProjectPostingRepo extends JpaRepository<Project, Long> {
     Optional<Project> findByJobPostingIdAndFreelancerId(Long jobPostingId, Long freelancerId);
 
     List<Project> findAllByEmployerIdOrderByCreatedAtDesc(Long employerId);
+
+    List<Project> findAllByFreelancerIdOrderByCreatedAtDesc(Long freelancerId);
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingService.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingService.java
@@ -37,4 +37,6 @@ public interface JobPostingService {
     List<AiRecommendationResponseDTO> getRecommendedJobsForFreelancer(Long userId);
 
     void completeProject(Long projectId, Long userId);
+
+    void refreshEmployerProjectStatsCache(Long employerId);
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
@@ -420,6 +420,15 @@ public class JobPostingServiceImpl implements JobPostingService {
     }
 
     private void refreshEmployerProjectStatsForMypage(Long employerId) {
+        refreshEmployerProjectStatsCache(employerId);
+    }
+
+    @Override
+    public void refreshEmployerProjectStatsCache(Long employerId) {
+        if (employerId == null) {
+            return;
+        }
+
         List<JobPosting> postings = orEmpty(jobPostingRepo.findAllByEmployerIdAndStatusNot(employerId, Status.DELETED));
         List<Project> projects = orEmpty(projectPostingRepo.findAllByEmployerIdOrderByCreatedAtDesc(employerId));
 

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
@@ -573,31 +573,35 @@ public class JobPostingServiceImpl implements JobPostingService {
                 .count();
 
         String redisKey = FREELANCER_PROJECT_STATS_KEY_PREFIX + freelancerId;
-        int appliedProjects = readAppliedProjectsCount(redisKey);
+        Map<String, Object> payload = readFreelancerProjectStatsPayload(redisKey);
+        Integer appliedProjects = readAppliedProjectsCount(payload);
+        if (appliedProjects != null) {
+            payload.put("appliedProjects", appliedProjects);
+        }
 
-        Map<String, Object> payload = new HashMap<>();
-        payload.put("appliedProjects", appliedProjects);
         payload.put("inProgressProjects", inProgressProjects);
         payload.put("completedProjects", completedProjects);
         writeMypageRedisValue(redisKey, payload);
     }
 
-    private int readAppliedProjectsCount(String redisKey) {
+    private Map<String, Object> readFreelancerProjectStatsPayload(String redisKey) {
+        Map<String, Object> payload = new HashMap<>();
         try {
             Object cached = redisTemplate.opsForValue().get(redisKey);
             if (cached instanceof Map<?, ?> map) {
-                Object value = map.get("appliedProjects");
-                if (value instanceof Number number) {
-                    return number.intValue();
-                }
-                if (value != null) {
-                    return Integer.parseInt(value.toString());
-                }
+                map.forEach((key, value) -> payload.put(String.valueOf(key), value));
             }
         } catch (RuntimeException e) {
-            log.warn("Failed to read applied project count from mypage redis key. key={}", redisKey, e);
+            log.warn("Failed to read freelancer project stats from mypage redis key. key={}", redisKey, e);
         }
-        return 0;
+        return payload;
+    }
+
+    private Integer readAppliedProjectsCount(Map<String, Object> payload) {
+        if (payload == null || !payload.containsKey("appliedProjects")) {
+            return null;
+        }
+        return parseIntegerSafely(payload.get("appliedProjects"));
     }
 
     private void evictEmployerSideCaches(Long employerId) {

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
@@ -38,6 +38,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -450,19 +451,51 @@ public class JobPostingServiceImpl implements JobPostingService {
     }
 
     private void refreshEmployerProjectListForMypage(Long employerId) {
+        String redisKey = EMPLOYER_PROJECT_LIST_KEY_PREFIX + employerId;
+        Map<Long, Integer> cachedApplicantCounts = readCachedEmployerApplicantCounts(redisKey);
+
         List<Map<String, Object>> payload = orEmpty(jobPostingRepo.findAllByEmployerIdAndStatusNot(employerId, Status.DELETED))
                 .stream()
-                .map(this::toEmployerProjectListItem)
+                .map(posting -> toEmployerProjectListItem(posting, cachedApplicantCounts.get(posting.getId())))
+                .sorted(Comparator.comparing(
+                        this::extractCreatedAt,
+                        Comparator.nullsLast(Comparator.naturalOrder())
+                ).reversed())
                 .toList();
-        writeMypageRedisValue(EMPLOYER_PROJECT_LIST_KEY_PREFIX + employerId, payload);
+        writeMypageRedisValue(redisKey, payload);
     }
 
-    private Map<String, Object> toEmployerProjectListItem(JobPosting posting) {
+    private Map<Long, Integer> readCachedEmployerApplicantCounts(String redisKey) {
+        Map<Long, Integer> applicantCounts = new HashMap<>();
+        try {
+            Object cached = redisTemplate.opsForValue().get(redisKey);
+            if (!(cached instanceof List<?> cachedList)) {
+                return applicantCounts;
+            }
+
+            for (Object entry : cachedList) {
+                if (!(entry instanceof Map<?, ?> cachedItem)) {
+                    continue;
+                }
+                Long projectId = parseLongSafely(cachedItem.get("projectId"));
+                Integer applicantCount = parseIntegerSafely(cachedItem.get("applicantCount"));
+                if (projectId == null || applicantCount == null) {
+                    continue;
+                }
+                applicantCounts.put(projectId, applicantCount);
+            }
+        } catch (RuntimeException e) {
+            log.warn("Failed to read employer project list cache for applicantCount reuse. key={}", redisKey, e);
+        }
+        return applicantCounts;
+    }
+
+    private Map<String, Object> toEmployerProjectListItem(JobPosting posting, Integer cachedApplicantCount) {
         Map<String, Object> item = new HashMap<>();
         item.put("projectId", posting.getId());
         item.put("title", posting.getTitle());
         item.put("status", toEmployerProjectStatus(posting.getPostingStatus()));
-        item.put("applicantCount", posting.getMatchedHeadcount());
+        item.put("applicantCount", cachedApplicantCount != null ? cachedApplicantCount : posting.getMatchedHeadcount());
 
         LocalDateTime createdAt = posting.getCreatedAt();
         item.put("createdAt", createdAt != null ? createdAt.format(ISO_SECONDS_FORMATTER) : null);
@@ -473,6 +506,49 @@ public class JobPostingServiceImpl implements JobPostingService {
         }
         item.put("deadline", deadline != null ? deadline.format(ISO_SECONDS_FORMATTER) : null);
         return item;
+    }
+
+    private LocalDateTime extractCreatedAt(Map<String, Object> item) {
+        if (item == null) {
+            return null;
+        }
+        Object createdAt = item.get("createdAt");
+        if (createdAt == null) {
+            return null;
+        }
+        try {
+            return LocalDateTime.parse(createdAt.toString(), ISO_SECONDS_FORMATTER);
+        } catch (RuntimeException ignored) {
+            return null;
+        }
+    }
+
+    private Long parseLongSafely(Object value) {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Long.parseLong(value.toString());
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private Integer parseIntegerSafely(Object value) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(value.toString());
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
     }
 
     private String toEmployerProjectStatus(JobPostingStatus status) {

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
@@ -15,6 +15,7 @@ import com.fallguys.recruitment.entity.JobPostingFavorite;
 import com.fallguys.recruitment.entity.JobPosting;
 import com.fallguys.recruitment.entity.JobPostingStatus;
 import com.fallguys.recruitment.entity.Project;
+import com.fallguys.recruitment.entity.ProjectStatus;
 import com.fallguys.recruitment.entity.Status;
 import com.fallguys.recruitment.repository.JobPostingFavoriteRepo;
 import com.fallguys.recruitment.repository.JobPostingRepo;
@@ -34,11 +35,15 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.transaction.support.TransactionSynchronization;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
 @Slf4j
@@ -50,6 +55,10 @@ public class JobPostingServiceImpl implements JobPostingService {
     private static final Duration CACHE_TTL = Duration.ofMinutes(10);
     private static final String CACHE_PREFIX = "recruitment";
     private static final int SCAN_BATCH_SIZE = 1000;
+    private static final String EMPLOYER_PROJECT_STATS_KEY_PREFIX = "employer:project:stats:";
+    private static final String EMPLOYER_PROJECT_LIST_KEY_PREFIX = "employer:project:list:";
+    private static final String FREELANCER_PROJECT_STATS_KEY_PREFIX = "freelancer:project:stats:";
+    private static final DateTimeFormatter ISO_SECONDS_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
     private final JobPostingRepo jobPostingRepo;
     private final JobPostingFavoriteRepo jobPostingFavoriteRepo;
@@ -84,7 +93,11 @@ public class JobPostingServiceImpl implements JobPostingService {
         RecruitmentUser user = recruitmentUserReader.getEmployerByIdOrThrow(userId);
         JobPosting jobPosting = JobPosting.from(jobPostingCreateDTO, user.id(), user.name());
         jobPostingRepo.save(jobPosting);
-        runAfterCommit(() -> evictEmployerSideCaches(user.id()));
+        runAfterCommit(() -> {
+            evictEmployerSideCaches(user.id());
+            refreshEmployerProjectStatsForMypage(user.id());
+            refreshEmployerProjectListForMypage(user.id());
+        });
     }
 
     @Override
@@ -99,7 +112,11 @@ public class JobPostingServiceImpl implements JobPostingService {
         } catch (IllegalArgumentException e) {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
-        runAfterCommit(() -> evictEmployerSideCaches(user.id()));
+        runAfterCommit(() -> {
+            evictEmployerSideCaches(user.id());
+            refreshEmployerProjectStatsForMypage(user.id());
+            refreshEmployerProjectListForMypage(user.id());
+        });
     }
 
     @Override
@@ -110,7 +127,11 @@ public class JobPostingServiceImpl implements JobPostingService {
         validateOwnership(jobPosting, user.id());
         validateNotDeleted(jobPosting);
         jobPosting.delete();
-        runAfterCommit(() -> evictEmployerSideCaches(user.id()));
+        runAfterCommit(() -> {
+            evictEmployerSideCaches(user.id());
+            refreshEmployerProjectStatsForMypage(user.id());
+            refreshEmployerProjectListForMypage(user.id());
+        });
     }
 
     @Override
@@ -362,7 +383,11 @@ public class JobPostingServiceImpl implements JobPostingService {
             syncTask.run();
         }
 
-        runAfterCommit(() -> redisTemplate.delete(employerProjectsCacheKey(userId)));
+        runAfterCommit(() -> {
+            redisTemplate.delete(employerProjectsCacheKey(userId));
+            refreshEmployerProjectStatsForMypage(userId);
+            refreshFreelancerProjectStatsForMypage(freelancerId);
+        });
     }
 
     private void runAfterCommit(Runnable task) {
@@ -392,6 +417,102 @@ public class JobPostingServiceImpl implements JobPostingService {
 
     private String freelancerSearchCacheKey(Long freelancerId, String normalizedKeyword, boolean favoritesOnly) {
         return CACHE_PREFIX + ":freelancer:search:" + freelancerId + ":" + normalizedKeyword + ":" + favoritesOnly;
+    }
+
+    private void refreshEmployerProjectStatsForMypage(Long employerId) {
+        List<JobPosting> postings = orEmpty(jobPostingRepo.findAllByEmployerIdAndStatusNot(employerId, Status.DELETED));
+        List<Project> projects = orEmpty(projectPostingRepo.findAllByEmployerIdOrderByCreatedAtDesc(employerId));
+
+        int activeApplicants = (int) projects.stream()
+                .filter(project -> project.getStatus() == ProjectStatus.IN_PROGRESS)
+                .count();
+        int contractedFreelancers = (int) projects.stream()
+                .map(Project::getFreelancerId)
+                .filter(id -> id != null)
+                .distinct()
+                .count();
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("totalProjects", postings.size());
+        payload.put("activeApplicants", activeApplicants);
+        payload.put("contractedFreelancers", contractedFreelancers);
+
+        writeMypageRedisValue(EMPLOYER_PROJECT_STATS_KEY_PREFIX + employerId, payload);
+    }
+
+    private void refreshEmployerProjectListForMypage(Long employerId) {
+        List<Map<String, Object>> payload = orEmpty(jobPostingRepo.findAllByEmployerIdAndStatusNot(employerId, Status.DELETED))
+                .stream()
+                .map(this::toEmployerProjectListItem)
+                .toList();
+        writeMypageRedisValue(EMPLOYER_PROJECT_LIST_KEY_PREFIX + employerId, payload);
+    }
+
+    private Map<String, Object> toEmployerProjectListItem(JobPosting posting) {
+        Map<String, Object> item = new HashMap<>();
+        item.put("projectId", posting.getId());
+        item.put("title", posting.getTitle());
+        item.put("status", toEmployerProjectStatus(posting.getPostingStatus()));
+        item.put("applicantCount", posting.getMatchedHeadcount());
+
+        LocalDateTime createdAt = posting.getCreatedAt();
+        item.put("createdAt", createdAt != null ? createdAt.format(ISO_SECONDS_FORMATTER) : null);
+
+        LocalDateTime deadline = createdAt;
+        if (createdAt != null && posting.getDuration() != null && posting.getDuration() > 0) {
+            deadline = createdAt.plusDays(posting.getDuration());
+        }
+        item.put("deadline", deadline != null ? deadline.format(ISO_SECONDS_FORMATTER) : null);
+        return item;
+    }
+
+    private String toEmployerProjectStatus(JobPostingStatus status) {
+        if (status == null) {
+            return "모집중";
+        }
+        return switch (status) {
+            case OPEN -> "모집중";
+            case IN_PROGRESS -> "진행중";
+            case COMPLETED -> "완료";
+            case CLOSED -> "마감";
+        };
+    }
+
+    private void refreshFreelancerProjectStatsForMypage(Long freelancerId) {
+        List<Project> projects = orEmpty(projectPostingRepo.findAllByFreelancerIdOrderByCreatedAtDesc(freelancerId));
+        int inProgressProjects = (int) projects.stream()
+                .filter(project -> project.getStatus() == ProjectStatus.IN_PROGRESS)
+                .count();
+        int completedProjects = (int) projects.stream()
+                .filter(project -> project.getStatus() == ProjectStatus.COMPLETED)
+                .count();
+
+        String redisKey = FREELANCER_PROJECT_STATS_KEY_PREFIX + freelancerId;
+        int appliedProjects = readAppliedProjectsCount(redisKey);
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("appliedProjects", appliedProjects);
+        payload.put("inProgressProjects", inProgressProjects);
+        payload.put("completedProjects", completedProjects);
+        writeMypageRedisValue(redisKey, payload);
+    }
+
+    private int readAppliedProjectsCount(String redisKey) {
+        try {
+            Object cached = redisTemplate.opsForValue().get(redisKey);
+            if (cached instanceof Map<?, ?> map) {
+                Object value = map.get("appliedProjects");
+                if (value instanceof Number number) {
+                    return number.intValue();
+                }
+                if (value != null) {
+                    return Integer.parseInt(value.toString());
+                }
+            }
+        } catch (RuntimeException e) {
+            log.warn("Failed to read applied project count from mypage redis key. key={}", redisKey, e);
+        }
+        return 0;
     }
 
     private void evictEmployerSideCaches(Long employerId) {
@@ -440,6 +561,18 @@ public class JobPostingServiceImpl implements JobPostingService {
         } catch (RuntimeException e) {
             log.warn("Failed to write cache. key={}", key, e);
         }
+    }
+
+    private void writeMypageRedisValue(String key, Object value) {
+        try {
+            redisTemplate.opsForValue().set(key, value);
+        } catch (RuntimeException e) {
+            log.warn("Failed to write mypage redis payload. key={}", key, e);
+        }
+    }
+
+    private <T> List<T> orEmpty(List<T> list) {
+        return list == null ? List.of() : list;
     }
 
     private <T> T readCache(String key, TypeReference<T> typeReference) {

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
@@ -94,7 +94,7 @@ public class JobPostingServiceImpl implements JobPostingService {
         RecruitmentUser user = recruitmentUserReader.getEmployerByIdOrThrow(userId);
         JobPosting jobPosting = JobPosting.from(jobPostingCreateDTO, user.id(), user.name());
         jobPostingRepo.save(jobPosting);
-        runAfterCommit(() -> {
+        runAfterCommitSafely(() -> {
             evictEmployerSideCaches(user.id());
             refreshEmployerProjectStatsForMypage(user.id());
             refreshEmployerProjectListForMypage(user.id());
@@ -113,7 +113,7 @@ public class JobPostingServiceImpl implements JobPostingService {
         } catch (IllegalArgumentException e) {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
-        runAfterCommit(() -> {
+        runAfterCommitSafely(() -> {
             evictEmployerSideCaches(user.id());
             refreshEmployerProjectStatsForMypage(user.id());
             refreshEmployerProjectListForMypage(user.id());
@@ -128,7 +128,7 @@ public class JobPostingServiceImpl implements JobPostingService {
         validateOwnership(jobPosting, user.id());
         validateNotDeleted(jobPosting);
         jobPosting.delete();
-        runAfterCommit(() -> {
+        runAfterCommitSafely(() -> {
             evictEmployerSideCaches(user.id());
             refreshEmployerProjectStatsForMypage(user.id());
             refreshEmployerProjectListForMypage(user.id());
@@ -214,7 +214,7 @@ public class JobPostingServiceImpl implements JobPostingService {
         } catch (DataIntegrityViolationException ignored) {
             // Duplicate favorite is treated as idempotent no-op.
         }
-        runAfterCommit(() -> evictFreelancerSearchCaches(freelancerId));
+        runAfterCommitSafely(() -> evictFreelancerSearchCaches(freelancerId));
     }
 
     @Override
@@ -224,7 +224,7 @@ public class JobPostingServiceImpl implements JobPostingService {
         Long freelancerId = user.id();
 
         jobPostingFavoriteRepo.deleteByFreelancerIdAndJobPostingId(freelancerId, jobPostingId);
-        runAfterCommit(() -> evictFreelancerSearchCaches(freelancerId));
+        runAfterCommitSafely(() -> evictFreelancerSearchCaches(freelancerId));
     }
 
     private JobPosting getJobPostingOrThrow(Long jobPostingId) {
@@ -384,7 +384,7 @@ public class JobPostingServiceImpl implements JobPostingService {
             syncTask.run();
         }
 
-        runAfterCommit(() -> {
+        runAfterCommitSafely(() -> {
             redisTemplate.delete(employerProjectsCacheKey(userId));
             refreshEmployerProjectStatsForMypage(userId);
             refreshFreelancerProjectStatsForMypage(freelancerId);
@@ -402,6 +402,16 @@ public class JobPostingServiceImpl implements JobPostingService {
             return;
         }
         task.run();
+    }
+
+    private void runAfterCommitSafely(Runnable task) {
+        runAfterCommit(() -> {
+            try {
+                task.run();
+            } catch (RuntimeException e) {
+                log.warn("Failed to execute post-commit task", e);
+            }
+        });
     }
 
     private String employerJobsCacheKey(Long employerId) {

--- a/freebridge/review/build.gradle
+++ b/freebridge/review/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation project(':matchs')
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'io.jsonwebtoken:jjwt-api:0.13.0'
     compileOnly 'org.springdoc:springdoc-openapi-starter-webmvc-ui'

--- a/freebridge/review/src/main/java/com/fallguys/review/repository/EmployerReviewRepository.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/repository/EmployerReviewRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface EmployerReviewRepository extends JpaRepository<EmployerReview, Long> {
@@ -30,4 +31,6 @@ public interface EmployerReviewRepository extends JpaRepository<EmployerReview, 
             Long freelancerId,
             ReviewStatus status
     );
+
+    List<EmployerReview> findAllByFreelancerIdAndStatus(Long freelancerId, ReviewStatus status);
 }

--- a/freebridge/review/src/main/java/com/fallguys/review/repository/FreelancerReviewRepository.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/repository/FreelancerReviewRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FreelancerReviewRepository extends JpaRepository<FreelancerReview, Long> {
@@ -30,4 +31,6 @@ public interface FreelancerReviewRepository extends JpaRepository<FreelancerRevi
             Long employerId,
             ReviewStatus status
     );
+
+    List<FreelancerReview> findAllByEmployerIdAndStatus(Long employerId, ReviewStatus status);
 }

--- a/freebridge/review/src/main/java/com/fallguys/review/service/ReviewServiceImpl.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/service/ReviewServiceImpl.java
@@ -12,22 +12,35 @@ import com.fallguys.review.entity.ReviewStatus;
 import com.fallguys.review.repository.EmployerReviewRepository;
 import com.fallguys.review.repository.FreelancerReviewRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ReviewServiceImpl implements ReviewService {
 
+    private static final String EMPLOYER_REVIEW_RATES_KEY_PREFIX = "employer:review:rates:";
+    private static final String FREELANCER_REVIEW_RATES_KEY_PREFIX = "freelancer:review:rates:";
+
     private final EmployerReviewRepository employerReviewRepository;
     private final FreelancerReviewRepository freelancerReviewRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
     public Page<FreelancerReview> getEmployerReceivedReviews(Long employerId, Pageable pageable) {
@@ -75,7 +88,9 @@ public class ReviewServiceImpl implements ReviewService {
                 .build();
 
         try {
-            return employerReviewRepository.save(review).getId();
+            Long reviewId = employerReviewRepository.save(review).getId();
+            runAfterCommitSafely(() -> refreshFreelancerReviewRates(request.freelancerId()));
+            return reviewId;
         } catch (DataIntegrityViolationException e) {
             if (!isDuplicateKeyViolation(e)) {
                 throw e;
@@ -103,6 +118,7 @@ public class ReviewServiceImpl implements ReviewService {
                 request.dispute(),
                 request.description()
         );
+        runAfterCommitSafely(() -> refreshFreelancerReviewRates(review.getFreelancerId()));
     }
 
     @Override
@@ -115,6 +131,7 @@ public class ReviewServiceImpl implements ReviewService {
                 )
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE));
         review.softDelete();
+        runAfterCommitSafely(() -> refreshFreelancerReviewRates(review.getFreelancerId()));
     }
 
     @Override
@@ -160,7 +177,9 @@ public class ReviewServiceImpl implements ReviewService {
                 .build();
 
         try {
-            return freelancerReviewRepository.save(review).getId();
+            Long reviewId = freelancerReviewRepository.save(review).getId();
+            runAfterCommitSafely(() -> refreshEmployerReviewRates(request.employerId()));
+            return reviewId;
         } catch (DataIntegrityViolationException e) {
             if (!isDuplicateKeyViolation(e)) {
                 throw e;
@@ -185,6 +204,7 @@ public class ReviewServiceImpl implements ReviewService {
                 request.schedule(),
                 request.description()
         );
+        runAfterCommitSafely(() -> refreshEmployerReviewRates(review.getEmployerId()));
     }
 
     @Override
@@ -197,6 +217,91 @@ public class ReviewServiceImpl implements ReviewService {
                 )
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE));
         review.softDelete();
+        runAfterCommitSafely(() -> refreshEmployerReviewRates(review.getEmployerId()));
+    }
+
+    private void runAfterCommit(Runnable task) {
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    task.run();
+                }
+            });
+            return;
+        }
+        task.run();
+    }
+
+    private void runAfterCommitSafely(Runnable task) {
+        runAfterCommit(() -> {
+            try {
+                task.run();
+            } catch (RuntimeException e) {
+                log.warn("Failed to refresh mypage review redis payload after commit", e);
+            }
+        });
+    }
+
+    private void refreshEmployerReviewRates(Long employerId) {
+        List<FreelancerReview> reviews = orEmpty(freelancerReviewRepository.findAllByEmployerIdAndStatus(employerId, ReviewStatus.ACTIVE));
+        List<Map<String, Object>> payload = new ArrayList<>(reviews.size());
+        for (FreelancerReview review : reviews) {
+            Map<String, Object> item = new HashMap<>();
+            item.put("atmosphereRate", toNumberOrZero(review.getAtmosphere()));
+            item.put("requirementsDetailRate", toNumberOrZero(review.getRequirementDetail()));
+            item.put("scheduleAdherenceRate", toNumberOrZero(review.getSchedule()));
+            payload.add(item);
+        }
+        writeRedisValue(EMPLOYER_REVIEW_RATES_KEY_PREFIX + employerId, payload);
+    }
+
+    private void refreshFreelancerReviewRates(Long freelancerId) {
+        List<EmployerReview> reviews = orEmpty(employerReviewRepository.findAllByFreelancerIdAndStatus(freelancerId, ReviewStatus.ACTIVE));
+        List<Map<String, Object>> payload = new ArrayList<>(reviews.size());
+        for (EmployerReview review : reviews) {
+            Map<String, Object> item = new HashMap<>();
+            item.put("expertiseRate", average(review.getLanguage(), review.getFramework(), review.getDebugging()));
+            item.put("communicationRate", toNumberOrZero(review.getCommunication()));
+            item.put("scheduleRate", toNumberOrZero(review.getSchedule()));
+            payload.add(item);
+        }
+        writeRedisValue(FREELANCER_REVIEW_RATES_KEY_PREFIX + freelancerId, payload);
+    }
+
+    private Number toNumberOrZero(Integer value) {
+        return value == null ? 0 : value;
+    }
+
+    private double average(Integer... values) {
+        int sum = 0;
+        int count = 0;
+        for (Integer value : values) {
+            if (value == null) {
+                continue;
+            }
+            sum += value;
+            count++;
+        }
+        if (count == 0) {
+            return 0.0;
+        }
+        return (double) sum / count;
+    }
+
+    private void writeRedisValue(String key, Object value) {
+        if (redisTemplate == null) {
+            return;
+        }
+        try {
+            redisTemplate.opsForValue().set(key, value);
+        } catch (RuntimeException e) {
+            log.warn("Failed to write mypage review payload. key={}", key, e);
+        }
+    }
+
+    private <T> List<T> orEmpty(List<T> list) {
+        return list == null ? List.of() : list;
     }
 
     private boolean isDuplicateKeyViolation(Throwable throwable) {


### PR DESCRIPTION
## 🔗 Related Issue
> 이슈 번호를 작성해주세요. (예: Closes #123)
- Closes #<이슈번호>

## 📝 작업 내용
마이페이지 Redis 연동 범위 중 `Contract` 도메인 누락분을 보완했습니다.  
계약 생성/서명/완료/거절 시점에 고용주/프리랜서 프로젝트 통계 키가 트랜잭션 커밋 이후 갱신되도록 구현했습니다.

## ✅ Changes
- `contract` 모듈에 Redis 의존성 추가
  - `org.springframework.boot:spring-boot-starter-data-redis`
- `ContractService`에 `RedisTemplate<String, Object>` 주입
- 계약 상태 변경 메서드에 Redis 갱신 트리거 추가
  - `createContract`
  - `sign`
  - `complete`
  - `reject`
- 커밋 이후 실행 보장 및 실패 무시(fail-open) 처리
  - `runAfterCommitSafely(...)` 추가
- 마이페이지 키 갱신 로직 추가
  - `employer:project:stats:{employerId}`
  - `freelancer:project:stats:{freelancerId}`
- 기존 Redis 값 병합 처리
  - 기존 값이 있으면 `appliedProjects` 등 기존 카운트 보존
  - 계약 상태 기반 `inProgress/completed/contracted` 값 최신화

## 📸 스크린샷 (선택)
> UI 변경 사항이나 테스트 결과 화면이 있다면 첨부해주세요.
- UI 변경 없음 (서버 로직/Redis 적재 로직 변경)

## ⚠️ Notes (Optional)
- Redis 적재 실패 시 비즈니스 트랜잭션은 실패시키지 않도록 경고 로그만 남기도록 처리했습니다.
- 검증:
  - `:matchs:compileJava :recruitment:compileJava :review:compileJava :contract:compileJava` 통과
  - `:contract:test --tests com.fallguys.contract.service.ContractServiceTest` 통과
  - 관련 모듈 서비스 테스트도 통과


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 마이페이지용 고용주/프리랜서 프로젝트 통계, 프로젝트 목록, 지원자·제안 집계 기능이 추가되었습니다.
  * 리뷰(고용주·프리랜서) 상태별 전체 조회 API가 추가되었습니다.
  * 공개용 캐시 갱신 호출 API(고용주 프로젝트 통계)가 추가되었습니다.

* **성능 개선**
  * Redis 기반 마이페이지·리뷰 평점 캐시가 도입되어 조회 응답 속도와 일관성이 향상되었습니다.
  * 캐시 갱신이 데이터베이스 커밋 이후에 안전하게 실행되도록 변경되었습니다.

* **잡무**
  * Redis 연동 및 관련 후속 처리 로직이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->