### PR TITLE
HFP-74 [feat] 프로젝트 매칭 프리랜서 목록 조회 API 구현

### DIFF
--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/response/MatchedFreelancerResponseDTO.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/response/MatchedFreelancerResponseDTO.java
@@ -1,0 +1,17 @@
+package com.fallguys.recruitment.api.dto.response;
+
+import com.fallguys.recruitment.entity.ProjectStatus;
+
+import java.time.LocalDateTime;
+
+public record MatchedFreelancerResponseDTO(
+        Long projectId,
+        Long freelancerId,
+        String freelancerName,
+        String skills,
+        String profileSummary,
+        String freelancerStatus,
+        ProjectStatus projectStatus,
+        LocalDateTime matchedAt
+) {
+}

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/web/JobPostingEmployerController.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/web/JobPostingEmployerController.java
@@ -6,6 +6,7 @@ import com.fallguys.recruitment.api.dto.request.JobPostingUpdateDTO;
 import com.fallguys.recruitment.api.dto.response.AiRecommendationResponseDTO;
 import com.fallguys.recruitment.api.dto.response.EmployerProjectSearchDTO;
 import com.fallguys.recruitment.api.dto.response.JobPostingSearchDTO;
+import com.fallguys.recruitment.api.dto.response.MatchedFreelancerResponseDTO;
 import com.fallguys.recruitment.api.dto.response.PagedResponseDTO;
 import com.fallguys.recruitment.api.support.TokenUserIdResolver;
 import com.fallguys.recruitment.api.util.PagingUtils;
@@ -57,6 +58,17 @@ public class JobPostingEmployerController {
         Long userId = tokenUserIdResolver.resolveUserId(authorization);
         List<EmployerProjectSearchDTO> result = jobPostingService.getEmployerProjects(userId);
         return ResponseEntity.ok(ApiResponse.ok(PagingUtils.toPagedResponse(result, page, size)));
+    }
+
+    @Operation(summary = "프로젝트 매칭 프리랜서 목록 조회", description = "프로젝트와 연결된 공고 기준으로 매칭된 프리랜서 목록을 조회합니다.")
+    @GetMapping("/api/employer/projects/{projectId}/matched-freelancers")
+    public ResponseEntity<ApiResponse<List<MatchedFreelancerResponseDTO>>> getMatchedFreelancers(
+            @RequestHeader("Authorization") String authorization,
+            @PathVariable Long projectId
+    ) {
+        Long userId = tokenUserIdResolver.resolveUserId(authorization);
+        List<MatchedFreelancerResponseDTO> result = jobPostingService.getMatchedFreelancers(projectId, userId);
+        return ResponseEntity.ok(ApiResponse.ok(result));
     }
 
     @Operation(summary = "채용 공고 등록", description = "새로운 채용 공고를 등록합니다.")

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/web/JobPostingEmployerController.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/web/JobPostingEmployerController.java
@@ -62,13 +62,15 @@ public class JobPostingEmployerController {
 
     @Operation(summary = "프로젝트 매칭 프리랜서 목록 조회", description = "프로젝트와 연결된 공고 기준으로 매칭된 프리랜서 목록을 조회합니다.")
     @GetMapping("/api/employer/projects/{projectId}/matched-freelancers")
-    public ResponseEntity<ApiResponse<List<MatchedFreelancerResponseDTO>>> getMatchedFreelancers(
+    public ResponseEntity<ApiResponse<PagedResponseDTO<MatchedFreelancerResponseDTO>>> getMatchedFreelancers(
             @RequestHeader("Authorization") String authorization,
-            @PathVariable Long projectId
+            @PathVariable Long projectId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
     ) {
         Long userId = tokenUserIdResolver.resolveUserId(authorization);
         List<MatchedFreelancerResponseDTO> result = jobPostingService.getMatchedFreelancers(projectId, userId);
-        return ResponseEntity.ok(ApiResponse.ok(result));
+        return ResponseEntity.ok(ApiResponse.ok(PagingUtils.toPagedResponse(result, page, size)));
     }
 
     @Operation(summary = "채용 공고 등록", description = "새로운 채용 공고를 등록합니다.")

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/web/JobPostingEmployerController.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/web/JobPostingEmployerController.java
@@ -15,6 +15,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -68,9 +70,21 @@ public class JobPostingEmployerController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
+        int safePage = Math.max(0, page);
+        int safeSize = Math.max(1, size);
         Long userId = tokenUserIdResolver.resolveUserId(authorization);
-        List<MatchedFreelancerResponseDTO> result = jobPostingService.getMatchedFreelancers(projectId, userId);
-        return ResponseEntity.ok(ApiResponse.ok(PagingUtils.toPagedResponse(result, page, size)));
+        Page<MatchedFreelancerResponseDTO> result = jobPostingService.getMatchedFreelancers(
+                projectId,
+                userId,
+                PageRequest.of(safePage, safeSize)
+        );
+        return ResponseEntity.ok(ApiResponse.ok(new PagedResponseDTO<>(
+                result.getContent(),
+                result.getNumber(),
+                result.getSize(),
+                result.getTotalElements(),
+                result.getTotalPages()
+        )));
     }
 
     @Operation(summary = "채용 공고 등록", description = "새로운 채용 공고를 등록합니다.")

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/infra/user/RecruitmentUserReaderImpl.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/infra/user/RecruitmentUserReaderImpl.java
@@ -11,6 +11,11 @@ import com.fallguys.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Component
@@ -31,15 +36,52 @@ public class RecruitmentUserReaderImpl implements RecruitmentUserReader {
 
     @Override
     public RecruitmentUser getFreelancerByIdOrThrow(Long userId) {
-        User user = getByIdOrThrow(userId);
+        RecruitmentUser freelancer = getFreelancersByIdsOrThrow(List.of(userId)).get(userId);
+        if (freelancer == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+        return freelancer;
+    }
 
-        if (user.getRole() != Role.FREELANCER) {
-            throw new BusinessException(ErrorCode.ONLY_FREELANCER_ALLOWED);
+    @Override
+    public Map<Long, RecruitmentUser> getFreelancersByIdsOrThrow(Collection<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return Map.of();
         }
 
-        var freelancer = freelancerRepository.findByUserId(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        LinkedHashSet<Long> uniqueUserIds = new LinkedHashSet<>(userIds);
+        Map<Long, User> usersById = userRepository.findAllById(uniqueUserIds)
+                .stream()
+                .collect(LinkedHashMap::new, (map, user) -> map.put(user.getId(), user), Map::putAll);
 
+        for (Long userId : uniqueUserIds) {
+            User user = usersById.get(userId);
+            if (user == null) {
+                throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+            }
+            if (user.getRole() != Role.FREELANCER) {
+                throw new BusinessException(ErrorCode.ONLY_FREELANCER_ALLOWED);
+            }
+        }
+
+        Map<Long, com.fallguys.mypage.entity.freelancer.Freelancer> freelancersByUserId =
+                freelancerRepository.findAllByUserIdIn(uniqueUserIds)
+                        .stream()
+                        .collect(LinkedHashMap::new, (map, freelancer) -> map.put(freelancer.getUserId(), freelancer), Map::putAll);
+
+        Map<Long, RecruitmentUser> result = new LinkedHashMap<>();
+        for (Long userId : uniqueUserIds) {
+            User user = usersById.get(userId);
+            var freelancer = freelancersByUserId.get(userId);
+            if (freelancer == null) {
+                throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+            }
+            result.put(userId, toRecruitmentFreelancer(user, freelancer));
+        }
+        return result;
+    }
+
+    private RecruitmentUser toRecruitmentFreelancer(User user, com.fallguys.mypage.entity.freelancer.Freelancer freelancer) {
         return new RecruitmentUser(
                 user.getId(),
                 user.getName(),

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/repository/ProjectPostingRepo.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/repository/ProjectPostingRepo.java
@@ -2,6 +2,8 @@ package com.fallguys.recruitment.repository;
 
 import com.fallguys.recruitment.entity.Project;
 import com.fallguys.recruitment.entity.ProjectStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -18,7 +20,7 @@ public interface ProjectPostingRepo extends JpaRepository<Project, Long> {
 
     List<Project> findAllByFreelancerIdOrderByCreatedAtDesc(Long freelancerId);
 
-    List<Project> findAllByJobPostingIdOrderByCreatedAtDesc(Long jobPostingId);
+    Page<Project> findAllByJobPostingIdOrderByCreatedAtDesc(Long jobPostingId, Pageable pageable);
 
     long countByFreelancerIdAndStatus(Long freelancerId, ProjectStatus status);
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/repository/ProjectPostingRepo.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/repository/ProjectPostingRepo.java
@@ -18,5 +18,7 @@ public interface ProjectPostingRepo extends JpaRepository<Project, Long> {
 
     List<Project> findAllByFreelancerIdOrderByCreatedAtDesc(Long freelancerId);
 
+    List<Project> findAllByJobPostingIdOrderByCreatedAtDesc(Long jobPostingId);
+
     long countByFreelancerIdAndStatus(Long freelancerId, ProjectStatus status);
 }

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingService.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingService.java
@@ -7,6 +7,8 @@ import com.fallguys.recruitment.api.dto.response.EmployerProjectSearchDTO;
 import com.fallguys.recruitment.api.dto.response.FreelancerJobPostingSearchDTO;
 import com.fallguys.recruitment.api.dto.response.JobPostingSearchDTO;
 import com.fallguys.recruitment.api.dto.response.MatchedFreelancerResponseDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -23,7 +25,7 @@ public interface JobPostingService {
 
     List<EmployerProjectSearchDTO> getEmployerProjects(Long userId);
 
-    List<MatchedFreelancerResponseDTO> getMatchedFreelancers(Long projectId, Long userId);
+    Page<MatchedFreelancerResponseDTO> getMatchedFreelancers(Long projectId, Long userId, Pageable pageable);
 
     List<FreelancerJobPostingSearchDTO> searchJobPostingsForFreelancer(
             Long userId,

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingService.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingService.java
@@ -6,6 +6,7 @@ import com.fallguys.recruitment.api.dto.response.AiRecommendationResponseDTO;
 import com.fallguys.recruitment.api.dto.response.EmployerProjectSearchDTO;
 import com.fallguys.recruitment.api.dto.response.FreelancerJobPostingSearchDTO;
 import com.fallguys.recruitment.api.dto.response.JobPostingSearchDTO;
+import com.fallguys.recruitment.api.dto.response.MatchedFreelancerResponseDTO;
 
 import java.util.List;
 
@@ -21,6 +22,8 @@ public interface JobPostingService {
     List<JobPostingSearchDTO> getAllJobPostings();
 
     List<EmployerProjectSearchDTO> getEmployerProjects(Long userId);
+
+    List<MatchedFreelancerResponseDTO> getMatchedFreelancers(Long projectId, Long userId);
 
     List<FreelancerJobPostingSearchDTO> searchJobPostingsForFreelancer(
             Long userId,

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
@@ -11,6 +11,7 @@ import com.fallguys.recruitment.api.dto.response.AiRecommendationResponseDTO;
 import com.fallguys.recruitment.api.dto.response.EmployerProjectSearchDTO;
 import com.fallguys.recruitment.api.dto.response.FreelancerJobPostingSearchDTO;
 import com.fallguys.recruitment.api.dto.response.JobPostingSearchDTO;
+import com.fallguys.recruitment.api.dto.response.MatchedFreelancerResponseDTO;
 import com.fallguys.recruitment.entity.JobPostingFavorite;
 import com.fallguys.recruitment.entity.JobPosting;
 import com.fallguys.recruitment.entity.JobPostingStatus;
@@ -169,6 +170,18 @@ public class JobPostingServiceImpl implements JobPostingService {
     }
 
     @Override
+    public List<MatchedFreelancerResponseDTO> getMatchedFreelancers(Long projectId, Long userId) {
+        RecruitmentUser employer = recruitmentUserReader.getEmployerByIdOrThrow(userId);
+        Project sourceProject = getProjectOrThrow(projectId);
+        validateProjectOwnership(sourceProject, employer.id());
+
+        return projectPostingRepo.findAllByJobPostingIdOrderByCreatedAtDesc(sourceProject.getJobPosting().getId())
+                .stream()
+                .map(this::toMatchedFreelancerResponseDto)
+                .toList();
+    }
+
+    @Override
     public List<FreelancerJobPostingSearchDTO> searchJobPostingsForFreelancer(Long userId, String keyword, boolean favoritesOnly) {
         RecruitmentUser user = recruitmentUserReader.getFreelancerByIdOrThrow(userId);
         Long freelancerId = user.id();
@@ -232,6 +245,11 @@ public class JobPostingServiceImpl implements JobPostingService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.JOB_POSTING_NOT_FOUND));
     }
 
+    private Project getProjectOrThrow(Long projectId) {
+        return projectPostingRepo.findById(projectId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
+    }
+
     private void validateOwnership(JobPosting jobPosting, Long userId) {
         if (!jobPosting.getEmployerId().equals(userId)) {
             throw new BusinessException(ErrorCode.JOB_POSTING_FORBIDDEN);
@@ -241,6 +259,12 @@ public class JobPostingServiceImpl implements JobPostingService {
     private void validateNotDeleted(JobPosting jobPosting) {
         if (jobPosting.getStatus() == Status.DELETED) {
             throw new BusinessException(ErrorCode.JOB_POSTING_ALREADY_DELETED);
+        }
+    }
+
+    private void validateProjectOwnership(Project project, Long userId) {
+        if (!project.getEmployerId().equals(userId)) {
+            throw new BusinessException(ErrorCode.JOB_POSTING_FORBIDDEN);
         }
     }
 
@@ -284,6 +308,20 @@ public class JobPostingServiceImpl implements JobPostingService {
                 project.getStartDate(),
                 project.getEndDate(),
                 project.getStatus()
+        );
+    }
+
+    private MatchedFreelancerResponseDTO toMatchedFreelancerResponseDto(Project project) {
+        RecruitmentUser freelancer = recruitmentUserReader.getFreelancerByIdOrThrow(project.getFreelancerId());
+        return new MatchedFreelancerResponseDTO(
+                project.getId(),
+                project.getFreelancerId(),
+                freelancer.name(),
+                freelancer.skills(),
+                freelancer.experience(),
+                freelancer.status(),
+                project.getStatus(),
+                project.getCreatedAt()
         );
     }
 

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
@@ -26,6 +26,8 @@ import com.fallguys.recruitment.service.port.RecruitmentUserReader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -170,15 +172,16 @@ public class JobPostingServiceImpl implements JobPostingService {
     }
 
     @Override
-    public List<MatchedFreelancerResponseDTO> getMatchedFreelancers(Long projectId, Long userId) {
+    public Page<MatchedFreelancerResponseDTO> getMatchedFreelancers(Long projectId, Long userId, Pageable pageable) {
         RecruitmentUser employer = recruitmentUserReader.getEmployerByIdOrThrow(userId);
         Project sourceProject = getProjectOrThrow(projectId);
         validateProjectOwnership(sourceProject, employer.id());
 
-        return projectPostingRepo.findAllByJobPostingIdOrderByCreatedAtDesc(sourceProject.getJobPosting().getId())
-                .stream()
-                .map(this::toMatchedFreelancerResponseDto)
-                .toList();
+        return projectPostingRepo.findAllByJobPostingIdOrderByCreatedAtDesc(
+                        sourceProject.getJobPosting().getId(),
+                        pageable
+                )
+                .map(this::toMatchedFreelancerResponseDto);
     }
 
     @Override

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
@@ -45,9 +45,11 @@ import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 @Slf4j
@@ -177,11 +179,22 @@ public class JobPostingServiceImpl implements JobPostingService {
         Project sourceProject = getProjectOrThrow(projectId);
         validateProjectOwnership(sourceProject, employer.id());
 
-        return projectPostingRepo.findAllByJobPostingIdOrderByCreatedAtDesc(
+        Page<Project> projects = projectPostingRepo.findAllByJobPostingIdOrderByCreatedAtDesc(
                         sourceProject.getJobPosting().getId(),
                         pageable
-                )
-                .map(this::toMatchedFreelancerResponseDto);
+                );
+
+        Map<Long, RecruitmentUser> freelancersById = recruitmentUserReader.getFreelancersByIdsOrThrow(
+                projects.getContent().stream()
+                        .map(Project::getFreelancerId)
+                        .filter(Objects::nonNull)
+                        .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new))
+        );
+
+        return projects.map(project -> toMatchedFreelancerResponseDto(
+                project,
+                getFreelancerOrThrow(freelancersById, project.getFreelancerId())
+        ));
     }
 
     @Override
@@ -314,8 +327,7 @@ public class JobPostingServiceImpl implements JobPostingService {
         );
     }
 
-    private MatchedFreelancerResponseDTO toMatchedFreelancerResponseDto(Project project) {
-        RecruitmentUser freelancer = recruitmentUserReader.getFreelancerByIdOrThrow(project.getFreelancerId());
+    private MatchedFreelancerResponseDTO toMatchedFreelancerResponseDto(Project project, RecruitmentUser freelancer) {
         return new MatchedFreelancerResponseDTO(
                 project.getId(),
                 project.getFreelancerId(),
@@ -326,6 +338,14 @@ public class JobPostingServiceImpl implements JobPostingService {
                 project.getStatus(),
                 project.getCreatedAt()
         );
+    }
+
+    private RecruitmentUser getFreelancerOrThrow(Map<Long, RecruitmentUser> freelancersById, Long freelancerId) {
+        RecruitmentUser freelancer = freelancersById.get(freelancerId);
+        if (freelancer == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+        return freelancer;
     }
 
     private boolean matchesKeyword(JobPosting jobPosting, String keyword) {

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/port/RecruitmentUserReader.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/port/RecruitmentUserReader.java
@@ -1,8 +1,13 @@
 package com.fallguys.recruitment.service.port;
 
+import java.util.Collection;
+import java.util.Map;
+
 public interface RecruitmentUserReader {
 
     RecruitmentUser getEmployerByIdOrThrow(Long userId);
 
     RecruitmentUser getFreelancerByIdOrThrow(Long userId);
+
+    Map<Long, RecruitmentUser> getFreelancersByIdsOrThrow(Collection<Long> userIds);
 }

--- a/freebridge/recruitment/src/test/java/com/fallguys/recruitment/api/web/JobPostingEmployerControllerTest.java
+++ b/freebridge/recruitment/src/test/java/com/fallguys/recruitment/api/web/JobPostingEmployerControllerTest.java
@@ -84,8 +84,8 @@ class JobPostingEmployerControllerTest {
     }
 
     @Test
-    @DisplayName("[TDD] 프로젝트 매칭 프리랜서 목록 조회 API는 토큰 userId를 해석해 서비스에 전달한다")
-    void getMatchedFreelancers_callsServiceAndReturnsOk() {
+    @DisplayName("[TDD] 프로젝트 매칭 프리랜서 목록 조회 API는 PagingUtils를 통해 page/size를 보정해 응답한다")
+    void getMatchedFreelancers_appliesPagingSafety() {
         String authorization = "Bearer token";
         Long projectId = 55L;
         when(tokenUserIdResolver.resolveUserId(authorization)).thenReturn(10L);
@@ -99,16 +99,42 @@ class JobPostingEmployerControllerTest {
                         "ACTIVE",
                         ProjectStatus.IN_PROGRESS,
                         LocalDateTime.of(2026, 3, 8, 18, 0)
+                ),
+                new MatchedFreelancerResponseDTO(
+                        56L,
+                        22L,
+                        "freelancer2",
+                        "[React]",
+                        "프론트엔드 3년",
+                        "POTENTIAL",
+                        ProjectStatus.IN_PROGRESS,
+                        LocalDateTime.of(2026, 3, 8, 17, 0)
+                ),
+                new MatchedFreelancerResponseDTO(
+                        57L,
+                        23L,
+                        "freelancer3",
+                        "[Node.js]",
+                        "풀스택 4년",
+                        "ACTIVE",
+                        ProjectStatus.COMPLETED,
+                        LocalDateTime.of(2026, 3, 8, 16, 0)
                 )
         ));
 
-        ResponseEntity<ApiResponse<List<MatchedFreelancerResponseDTO>>> response =
-                controller.getMatchedFreelancers(authorization, projectId);
+        ResponseEntity<ApiResponse<PagedResponseDTO<MatchedFreelancerResponseDTO>>> response =
+                controller.getMatchedFreelancers(authorization, projectId, -1, 0);
 
         verify(jobPostingService, times(1)).getMatchedFreelancers(projectId, 10L);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
         assertEquals(true, response.getBody().success());
-        assertEquals(1, response.getBody().data().size());
+
+        PagedResponseDTO<MatchedFreelancerResponseDTO> paged = response.getBody().data();
+        assertEquals(0, paged.page());
+        assertEquals(1, paged.size());
+        assertEquals(3L, paged.totalElements());
+        assertEquals(3, paged.totalPages());
+        assertEquals(1, paged.content().size());
     }
 }

--- a/freebridge/recruitment/src/test/java/com/fallguys/recruitment/api/web/JobPostingEmployerControllerTest.java
+++ b/freebridge/recruitment/src/test/java/com/fallguys/recruitment/api/web/JobPostingEmployerControllerTest.java
@@ -3,9 +3,11 @@ package com.fallguys.recruitment.api.web;
 import com.fallguys.common.response.ApiResponse;
 import com.fallguys.recruitment.api.dto.request.JobPostingCreateDTO;
 import com.fallguys.recruitment.api.dto.response.JobPostingSearchDTO;
+import com.fallguys.recruitment.api.dto.response.MatchedFreelancerResponseDTO;
 import com.fallguys.recruitment.api.dto.response.PagedResponseDTO;
 import com.fallguys.recruitment.api.support.TokenUserIdResolver;
 import com.fallguys.recruitment.entity.JobPostingStatus;
+import com.fallguys.recruitment.entity.ProjectStatus;
 import com.fallguys.recruitment.service.JobPostingService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.util.List;
+import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -78,5 +81,34 @@ class JobPostingEmployerControllerTest {
         assertEquals(2L, paged.totalElements());
         assertEquals(2, paged.totalPages());
         assertEquals(1, paged.content().size());
+    }
+
+    @Test
+    @DisplayName("[TDD] 프로젝트 매칭 프리랜서 목록 조회 API는 토큰 userId를 해석해 서비스에 전달한다")
+    void getMatchedFreelancers_callsServiceAndReturnsOk() {
+        String authorization = "Bearer token";
+        Long projectId = 55L;
+        when(tokenUserIdResolver.resolveUserId(authorization)).thenReturn(10L);
+        when(jobPostingService.getMatchedFreelancers(projectId, 10L)).thenReturn(List.of(
+                new MatchedFreelancerResponseDTO(
+                        55L,
+                        21L,
+                        "freelancer",
+                        "[Java, Spring]",
+                        "백엔드 5년",
+                        "ACTIVE",
+                        ProjectStatus.IN_PROGRESS,
+                        LocalDateTime.of(2026, 3, 8, 18, 0)
+                )
+        ));
+
+        ResponseEntity<ApiResponse<List<MatchedFreelancerResponseDTO>>> response =
+                controller.getMatchedFreelancers(authorization, projectId);
+
+        verify(jobPostingService, times(1)).getMatchedFreelancers(projectId, 10L);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(true, response.getBody().success());
+        assertEquals(1, response.getBody().data().size());
     }
 }

--- a/freebridge/recruitment/src/test/java/com/fallguys/recruitment/api/web/JobPostingEmployerControllerTest.java
+++ b/freebridge/recruitment/src/test/java/com/fallguys/recruitment/api/web/JobPostingEmployerControllerTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -84,12 +86,12 @@ class JobPostingEmployerControllerTest {
     }
 
     @Test
-    @DisplayName("[TDD] 프로젝트 매칭 프리랜서 목록 조회 API는 PagingUtils를 통해 page/size를 보정해 응답한다")
+    @DisplayName("[TDD] 프로젝트 매칭 프리랜서 목록 조회 API는 안전한 PageRequest를 사용해 페이징 응답한다")
     void getMatchedFreelancers_appliesPagingSafety() {
         String authorization = "Bearer token";
         Long projectId = 55L;
         when(tokenUserIdResolver.resolveUserId(authorization)).thenReturn(10L);
-        when(jobPostingService.getMatchedFreelancers(projectId, 10L)).thenReturn(List.of(
+        when(jobPostingService.getMatchedFreelancers(projectId, 10L, PageRequest.of(0, 1))).thenReturn(new PageImpl<>(List.of(
                 new MatchedFreelancerResponseDTO(
                         55L,
                         21L,
@@ -99,33 +101,13 @@ class JobPostingEmployerControllerTest {
                         "ACTIVE",
                         ProjectStatus.IN_PROGRESS,
                         LocalDateTime.of(2026, 3, 8, 18, 0)
-                ),
-                new MatchedFreelancerResponseDTO(
-                        56L,
-                        22L,
-                        "freelancer2",
-                        "[React]",
-                        "프론트엔드 3년",
-                        "POTENTIAL",
-                        ProjectStatus.IN_PROGRESS,
-                        LocalDateTime.of(2026, 3, 8, 17, 0)
-                ),
-                new MatchedFreelancerResponseDTO(
-                        57L,
-                        23L,
-                        "freelancer3",
-                        "[Node.js]",
-                        "풀스택 4년",
-                        "ACTIVE",
-                        ProjectStatus.COMPLETED,
-                        LocalDateTime.of(2026, 3, 8, 16, 0)
                 )
-        ));
+        ), PageRequest.of(0, 1), 3));
 
         ResponseEntity<ApiResponse<PagedResponseDTO<MatchedFreelancerResponseDTO>>> response =
                 controller.getMatchedFreelancers(authorization, projectId, -1, 0);
 
-        verify(jobPostingService, times(1)).getMatchedFreelancers(projectId, 10L);
+        verify(jobPostingService, times(1)).getMatchedFreelancers(projectId, 10L, PageRequest.of(0, 1));
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
         assertEquals(true, response.getBody().success());

--- a/freebridge/recruitment/src/test/java/com/fallguys/recruitment/service/JobPostingServiceCoreTest.java
+++ b/freebridge/recruitment/src/test/java/com/fallguys/recruitment/service/JobPostingServiceCoreTest.java
@@ -189,10 +189,11 @@ class JobPostingServiceCoreTest {
         when(projectPostingRepo.findById(projectId)).thenReturn(Optional.of(sourceProject));
         when(projectPostingRepo.findAllByJobPostingIdOrderByCreatedAtDesc(jobPostingId, pageable))
                 .thenReturn(new PageImpl<>(List.of(sourceProject, anotherProject), pageable, 2));
-        when(recruitmentUserReader.getFreelancerByIdOrThrow(77L))
-                .thenReturn(new RecruitmentUser(77L, "kim", "[Java]", "백엔드", "ACTIVE"));
-        when(recruitmentUserReader.getFreelancerByIdOrThrow(88L))
-                .thenReturn(new RecruitmentUser(88L, "lee", "[Spring]", "풀스택", "POTENTIAL"));
+        when(recruitmentUserReader.getFreelancersByIdsOrThrow(new java.util.LinkedHashSet<>(List.of(77L, 88L))))
+                .thenReturn(java.util.Map.of(
+                        77L, new RecruitmentUser(77L, "kim", "[Java]", "백엔드", "ACTIVE"),
+                        88L, new RecruitmentUser(88L, "lee", "[Spring]", "풀스택", "POTENTIAL")
+                ));
 
         Page<MatchedFreelancerResponseDTO> result = service.getMatchedFreelancers(projectId, employerId, pageable);
 
@@ -202,6 +203,7 @@ class JobPostingServiceCoreTest {
         assertEquals("kim", result.getContent().get(0).freelancerName());
         assertEquals(88L, result.getContent().get(1).freelancerId());
         assertEquals("lee", result.getContent().get(1).freelancerName());
+        verify(recruitmentUserReader, never()).getFreelancerByIdOrThrow(any());
     }
 
     @Test

--- a/freebridge/recruitment/src/test/java/com/fallguys/recruitment/service/JobPostingServiceCoreTest.java
+++ b/freebridge/recruitment/src/test/java/com/fallguys/recruitment/service/JobPostingServiceCoreTest.java
@@ -25,6 +25,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -173,6 +176,7 @@ class JobPostingServiceCoreTest {
         Long employerId = 5L;
         Long projectId = 40L;
         Long jobPostingId = 100L;
+        PageRequest pageable = PageRequest.of(0, 2);
         Project sourceProject = Project.create(posting(jobPostingId, employerId, Status.ACTIVE), 77L);
         Project anotherProject = Project.create(posting(jobPostingId, employerId, Status.ACTIVE), 88L);
         ReflectionTestUtils.setField(sourceProject, "id", projectId, Long.class);
@@ -183,20 +187,21 @@ class JobPostingServiceCoreTest {
         when(recruitmentUserReader.getEmployerByIdOrThrow(employerId))
                 .thenReturn(new RecruitmentUser(employerId, "employer", null, null, "ACTIVE"));
         when(projectPostingRepo.findById(projectId)).thenReturn(Optional.of(sourceProject));
-        when(projectPostingRepo.findAllByJobPostingIdOrderByCreatedAtDesc(jobPostingId))
-                .thenReturn(List.of(sourceProject, anotherProject));
+        when(projectPostingRepo.findAllByJobPostingIdOrderByCreatedAtDesc(jobPostingId, pageable))
+                .thenReturn(new PageImpl<>(List.of(sourceProject, anotherProject), pageable, 2));
         when(recruitmentUserReader.getFreelancerByIdOrThrow(77L))
                 .thenReturn(new RecruitmentUser(77L, "kim", "[Java]", "백엔드", "ACTIVE"));
         when(recruitmentUserReader.getFreelancerByIdOrThrow(88L))
                 .thenReturn(new RecruitmentUser(88L, "lee", "[Spring]", "풀스택", "POTENTIAL"));
 
-        List<MatchedFreelancerResponseDTO> result = service.getMatchedFreelancers(projectId, employerId);
+        Page<MatchedFreelancerResponseDTO> result = service.getMatchedFreelancers(projectId, employerId, pageable);
 
-        assertEquals(2, result.size());
-        assertEquals(77L, result.get(0).freelancerId());
-        assertEquals("kim", result.get(0).freelancerName());
-        assertEquals(88L, result.get(1).freelancerId());
-        assertEquals("lee", result.get(1).freelancerName());
+        assertEquals(2, result.getContent().size());
+        assertEquals(2L, result.getTotalElements());
+        assertEquals(77L, result.getContent().get(0).freelancerId());
+        assertEquals("kim", result.getContent().get(0).freelancerName());
+        assertEquals(88L, result.getContent().get(1).freelancerId());
+        assertEquals("lee", result.getContent().get(1).freelancerName());
     }
 
     @Test
@@ -225,6 +230,7 @@ class JobPostingServiceCoreTest {
         Long employerId = 5L;
         Long projectId = 40L;
         Project project = Project.create(posting(100L, 99L, Status.ACTIVE), 77L);
+        PageRequest pageable = PageRequest.of(0, 10);
 
         when(recruitmentUserReader.getEmployerByIdOrThrow(employerId))
                 .thenReturn(new RecruitmentUser(employerId, "employer", null, null, "ACTIVE"));
@@ -232,7 +238,7 @@ class JobPostingServiceCoreTest {
 
         BusinessException ex = assertThrows(
                 BusinessException.class,
-                () -> service.getMatchedFreelancers(projectId, employerId)
+                () -> service.getMatchedFreelancers(projectId, employerId, pageable)
         );
 
         assertEquals(ErrorCode.JOB_POSTING_FORBIDDEN, ex.getErrorCode());

--- a/freebridge/recruitment/src/test/java/com/fallguys/recruitment/service/JobPostingServiceCoreTest.java
+++ b/freebridge/recruitment/src/test/java/com/fallguys/recruitment/service/JobPostingServiceCoreTest.java
@@ -7,6 +7,7 @@ import com.fallguys.common.exception.ErrorCode;
 import com.fallguys.recruitment.api.dto.request.JobPostingCreateDTO;
 import com.fallguys.recruitment.api.dto.request.JobPostingUpdateDTO;
 import com.fallguys.recruitment.api.dto.response.AiRecommendationResponseDTO;
+import com.fallguys.recruitment.api.dto.response.MatchedFreelancerResponseDTO;
 import com.fallguys.recruitment.entity.JobPosting;
 import com.fallguys.recruitment.entity.JobPostingStatus;
 import com.fallguys.recruitment.entity.Project;
@@ -29,6 +30,7 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -166,6 +168,38 @@ class JobPostingServiceCoreTest {
     }
 
     @Test
+    @DisplayName("[TDD] 프로젝트 매칭 프리랜서 목록 조회 시 같은 공고에 매칭된 프리랜서를 반환한다")
+    void getMatchedFreelancers_returnsMatchedFreelancersForSameJobPosting() {
+        Long employerId = 5L;
+        Long projectId = 40L;
+        Long jobPostingId = 100L;
+        Project sourceProject = Project.create(posting(jobPostingId, employerId, Status.ACTIVE), 77L);
+        Project anotherProject = Project.create(posting(jobPostingId, employerId, Status.ACTIVE), 88L);
+        ReflectionTestUtils.setField(sourceProject, "id", projectId, Long.class);
+        ReflectionTestUtils.setField(sourceProject, "createdAt", LocalDateTime.of(2026, 3, 8, 10, 0));
+        ReflectionTestUtils.setField(anotherProject, "id", 41L, Long.class);
+        ReflectionTestUtils.setField(anotherProject, "createdAt", LocalDateTime.of(2026, 3, 8, 9, 0));
+
+        when(recruitmentUserReader.getEmployerByIdOrThrow(employerId))
+                .thenReturn(new RecruitmentUser(employerId, "employer", null, null, "ACTIVE"));
+        when(projectPostingRepo.findById(projectId)).thenReturn(Optional.of(sourceProject));
+        when(projectPostingRepo.findAllByJobPostingIdOrderByCreatedAtDesc(jobPostingId))
+                .thenReturn(List.of(sourceProject, anotherProject));
+        when(recruitmentUserReader.getFreelancerByIdOrThrow(77L))
+                .thenReturn(new RecruitmentUser(77L, "kim", "[Java]", "백엔드", "ACTIVE"));
+        when(recruitmentUserReader.getFreelancerByIdOrThrow(88L))
+                .thenReturn(new RecruitmentUser(88L, "lee", "[Spring]", "풀스택", "POTENTIAL"));
+
+        List<MatchedFreelancerResponseDTO> result = service.getMatchedFreelancers(projectId, employerId);
+
+        assertEquals(2, result.size());
+        assertEquals(77L, result.get(0).freelancerId());
+        assertEquals("kim", result.get(0).freelancerName());
+        assertEquals(88L, result.get(1).freelancerId());
+        assertEquals("lee", result.get(1).freelancerName());
+    }
+
+    @Test
     @DisplayName("[TDD] 프로젝트 완료 시 이미 완료된 프로젝트면 PROJECT_ALREADY_COMPLETED 예외")
     void completeProject_alreadyCompleted_throws() {
         // given
@@ -183,6 +217,25 @@ class JobPostingServiceCoreTest {
 
         // then
         assertEquals(ErrorCode.PROJECT_ALREADY_COMPLETED, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("[TDD] 프로젝트 매칭 프리랜서 목록 조회 시 소유자가 다르면 JOB_POSTING_FORBIDDEN 예외")
+    void getMatchedFreelancers_forbiddenOwner_throws() {
+        Long employerId = 5L;
+        Long projectId = 40L;
+        Project project = Project.create(posting(100L, 99L, Status.ACTIVE), 77L);
+
+        when(recruitmentUserReader.getEmployerByIdOrThrow(employerId))
+                .thenReturn(new RecruitmentUser(employerId, "employer", null, null, "ACTIVE"));
+        when(projectPostingRepo.findById(projectId)).thenReturn(Optional.of(project));
+
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> service.getMatchedFreelancers(projectId, employerId)
+        );
+
+        assertEquals(ErrorCode.JOB_POSTING_FORBIDDEN, ex.getErrorCode());
     }
 
     private JobPosting posting(Long id, Long employerId, Status status) {

--- a/freebridge/user/src/main/java/com/fallguys/mypage/repository/freelancer/FreelancerRepository.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/repository/freelancer/FreelancerRepository.java
@@ -4,6 +4,8 @@ import com.fallguys.mypage.entity.freelancer.Freelancer;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -11,4 +13,5 @@ public interface FreelancerRepository extends JpaRepository<Freelancer, Long> {
 
     Optional<Freelancer> findByUserId(Long userId);
 
+    List<Freelancer> findAllByUserIdIn(Collection<Long> userIds);
 }


### PR DESCRIPTION
## 🔗 Related Issue
> 이슈 번호를 작성해주세요. (예: Closes #123)
- Closes #

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

recruitment 모듈에 고용주가 프로젝트에 매칭된 프리랜서 목록을 조회할 수 있는 API를 추가했습니다.
기존 목록 조회 API와 동일한 방식으로 `page`, `size` 기반 페이징 응답을 적용했습니다.

## ✅ Changes
> 주요 변경 사항을 bullet point로 정리합니다.

- `GET /api/employer/projects/{projectId}/matched-freelancers` API 추가
- 프로젝트 소유자 검증 후 동일 공고에 매칭된 프리랜서 목록 조회 로직 추가
- `MatchedFreelancerResponseDTO` 응답 DTO 추가
- `ProjectPostingRepo`에 공고 기준 매칭 프로젝트 조회 메서드 추가
- 기존 employer 목록 API와 동일하게 `PagedResponseDTO` + `PagingUtils` 방식으로 응답 통일
- 컨트롤러/서비스 테스트 추가 및 검증

## 📸 스크린샷 (선택)
> UI 변경 사항이나 테스트 결과 화면이 있다면 첨부해주세요.
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
> 리뷰 시 유의할 점, 후속 PR 예정 사항, 배포 영향 등을 적습니다.

- API 조회 기준은 전달받은 `projectId`가 속한 공고(`jobPostingId`)의 전체 매칭 프리랜서 목록입니다.
- 애플리케이션 실행 시 JWT 관련 환경변수(`JWT_SECRET`)는 기존과 동일하게 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 고용주가 특정 프로젝트에 매칭된 프리랜서 목록을 조회할 수 있는 API 추가 — 프리랜서 이름, 스킬, 프로필 요약, 상태 및 매칭 시각을 포함하고 페이징 지원
* **테스트**
  * 페이징 안전성, 소유권 검증 및 매칭 조회 동작을 검증하는 단위/컨트롤러 테스트 추가
* **수정/개선**
  * 다수 프리랜서 조회와 페이징 처리 관련 백엔드 조회 로직 개선 (성능·안정성 향상)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->