### PR TITLE
HFP-74 fix(review): 리뷰 등록 오류와 프로젝트 완료 예외 처리 개선

### DIFF
--- a/freebridge/review/src/main/java/com/fallguys/review/entity/EmployerReview.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/entity/EmployerReview.java
@@ -71,6 +71,10 @@ public class EmployerReview {
     @Column(name = "status", nullable = false, length = 20)
     private ReviewStatus status = ReviewStatus.ACTIVE;
 
+    @Builder.Default
+    @Column(name = "deleted", nullable = false)
+    private Boolean deleted = false;
+
     @PrePersist
     protected void onCreate() {
         LocalDateTime now = LocalDateTime.now();
@@ -103,5 +107,6 @@ public class EmployerReview {
 
     public void softDelete() {
         this.status = ReviewStatus.DELETED;
+        this.deleted = true;
     }
 }

--- a/freebridge/review/src/main/java/com/fallguys/review/entity/FreelancerReview.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/entity/FreelancerReview.java
@@ -62,6 +62,10 @@ public class FreelancerReview {
     @Column(name = "status", nullable = false, length = 20)
     private ReviewStatus status = ReviewStatus.ACTIVE;
 
+    @Builder.Default
+    @Column(name = "deleted", nullable = false)
+    private Boolean deleted = false;
+
     @PrePersist
     protected void onCreate() {
         LocalDateTime now = LocalDateTime.now();
@@ -88,5 +92,6 @@ public class FreelancerReview {
 
     public void softDelete() {
         this.status = ReviewStatus.DELETED;
+        this.deleted = true;
     }
 }

--- a/freebridge/review/src/test/java/com/fallguys/review/service/ReviewServiceImplTest.java
+++ b/freebridge/review/src/test/java/com/fallguys/review/service/ReviewServiceImplTest.java
@@ -2,6 +2,7 @@ package com.fallguys.review.service;
 
 import com.fallguys.common.exception.BusinessException;
 import com.fallguys.common.exception.ErrorCode;
+import com.fallguys.common.port.ProjectExternalApi;
 import com.fallguys.review.api.dto.request.EmployerReviewCreateRequest;
 import com.fallguys.review.api.dto.request.EmployerReviewUpdateRequest;
 import com.fallguys.review.api.dto.request.FreelancerReviewCreateRequest;
@@ -38,6 +39,9 @@ class ReviewServiceImplTest {
 
     @Mock
     private FreelancerReviewRepository freelancerReviewRepository;
+
+    @Mock
+    private ProjectExternalApi projectExternalApi;
 
     @InjectMocks
     private ReviewServiceImpl reviewService;
@@ -79,6 +83,7 @@ class ReviewServiceImplTest {
         verify(employerReviewRepository, times(1)).save(captor.capture());
         assertEquals(employerId, captor.getValue().getEmployerId());
         assertEquals(request.freelancerId(), captor.getValue().getFreelancerId());
+        verify(projectExternalApi, times(1)).completeProjectWithReview(any());
     }
 
     @Test
@@ -141,6 +146,7 @@ class ReviewServiceImplTest {
 
         // then
         assertEquals(ReviewStatus.DELETED, review.getStatus());
+        assertEquals(true, review.getDeleted());
     }
 
     @Test
@@ -204,5 +210,6 @@ class ReviewServiceImplTest {
 
         // then
         assertEquals(ReviewStatus.DELETED, review.getStatus());
+        assertEquals(true, review.getDeleted());
     }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #이슈번호

## 📝 작업 내용
리뷰 등록 시 발생하던 500 에러를 수정하고, 리뷰 soft delete 및 프로젝트 완료 처리 로직을 보완했습니다.

## ✅ Changes
- `EmployerReview`, `FreelancerReview` 엔티티에 `deleted` 컬럼 매핑 추가 및 기본값 `false` 반영
- 리뷰 삭제 시 `status=DELETED`와 함께 `deleted=true`가 저장되도록 수정
- 리뷰 등록 후 프로젝트 완료 처리 시 이미 완료된 프로젝트는 예외 없이 넘어가도록 보완
- 리뷰 등록/삭제 및 프로젝트 완료 처리 관련 테스트 추가 및 검증

## 📸 스크린샷 (선택)
백엔드 변경 사항으로 별도 스크린샷은 없습니다.

## ⚠️ Notes (Optional)
- DB의 `deleted NOT NULL` 제약과 엔티티 매핑 불일치로 발생하던 오류를 해결했습니다.
- 테스트:
  `./gradlew :review:test --tests com.fallguys.review.service.ReviewServiceImplTest :recruitment:test --tests com.fallguys.recruitment.service.ProjectExternalApiImplTest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 리뷰 소프트 삭제 기능 강화: 고용주 및 프리랜서 리뷰의 삭제 상태를 더욱 효과적으로 추적할 수 있도록 개선되었습니다.

* **Tests**
  * 리뷰 삭제 기능에 대한 검증 로직 추가: 소프트 삭제 이후 상태가 올바르게 업데이트되는지 확인하는 테스트가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->