### PR TITLE
HFP-74 fix(application): 지원/거절 이력 저장 및 프로젝트 상태 전이 보완

### DIFF
--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
@@ -170,6 +170,7 @@ public class MatchsServiceImpl implements MatchsService {
         validatePending(application.getStatus());
 
         application.reject();
+        ensureRejectedProjectHistory(application.getJobPostingId(), application.getFreelancerId());
         runAfterCommitSafely(() -> {
             refreshEmployerProjectStats(application.getEmployerId());
             refreshEmployerProjectList(application.getEmployerId());
@@ -190,6 +191,7 @@ public class MatchsServiceImpl implements MatchsService {
         validatePending(proposal.getStatus());
 
         proposal.reject();
+        ensureRejectedProjectHistory(proposal.getJobPostingId(), freelancerId);
         runAfterCommitSafely(() -> {
             refreshEmployerProjectStats(proposal.getEmployerId());
             refreshEmployerProjectList(proposal.getEmployerId());
@@ -263,6 +265,13 @@ public class MatchsServiceImpl implements MatchsService {
         JobPosting jobPosting = getOpenJobPostingForUpdateOrThrow(jobPostingId);
         Project existing = projectPostingRepo.findByJobPostingIdAndFreelancerId(jobPostingId, freelancerId).orElse(null);
         if (existing != null) {
+            if (existing.getStatus() == ProjectStatus.CANCELLED) {
+                if (jobPosting.isRecruitmentFull()) {
+                    throw new BusinessException(ErrorCode.JOB_POSTING_HEADCOUNT_FULL);
+                }
+                existing.reopen();
+                jobPosting.matchFreelancer();
+            }
             return existing.getId();
         }
 
@@ -274,6 +283,18 @@ public class MatchsServiceImpl implements MatchsService {
         Long projectId = projectPostingRepo.save(project).getId();
         jobPosting.matchFreelancer();
         return projectId;
+    }
+
+    private Long ensureRejectedProjectHistory(Long jobPostingId, Long freelancerId) {
+        JobPosting jobPosting = getJobPostingForProjectHistoryOrThrow(jobPostingId);
+        Project existing = projectPostingRepo.findByJobPostingIdAndFreelancerId(jobPostingId, freelancerId).orElse(null);
+        if (existing != null) {
+            return existing.getId();
+        }
+
+        Project project = Project.create(jobPosting, freelancerId);
+        project.cancel();
+        return projectPostingRepo.save(project).getId();
     }
 
     private Application getApplicationOrThrow(Long applicationId) {
@@ -302,6 +323,11 @@ public class MatchsServiceImpl implements MatchsService {
             throw new BusinessException(ErrorCode.JOB_POSTING_ALREADY_DELETED);
         }
         return jobPosting;
+    }
+
+    private JobPosting getJobPostingForProjectHistoryOrThrow(Long jobPostingId) {
+        return jobPostingRepo.findByIdForUpdate(jobPostingId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.JOB_POSTING_NOT_FOUND));
     }
 
     private User getUserByRoleOrThrow(Long userId, Role role) {

--- a/freebridge/matchs/src/test/java/com/fallguys/matchs/service/MatchsServiceImplTest.java
+++ b/freebridge/matchs/src/test/java/com/fallguys/matchs/service/MatchsServiceImplTest.java
@@ -12,6 +12,7 @@ import com.fallguys.matchs.repository.ProposalRepo;
 import com.fallguys.recruitment.api.dto.request.JobPostingCreateDTO;
 import com.fallguys.recruitment.entity.JobPosting;
 import com.fallguys.recruitment.entity.Project;
+import com.fallguys.recruitment.entity.ProjectStatus;
 import com.fallguys.recruitment.entity.Status;
 import com.fallguys.recruitment.repository.JobPostingRepo;
 import com.fallguys.recruitment.repository.ProjectPostingRepo;
@@ -148,6 +149,36 @@ class MatchsServiceImplTest {
     }
 
     @Test
+    @DisplayName("[TDD] 지원 수락 시 기존 취소 프로젝트가 있으면 진행중으로 복구한다")
+    void acceptApplication_cancelledProject_reopensExistingProject() {
+        // given
+        Long employerId = 1L;
+        Long applicationId = 12L;
+        Application application = Application.create(302L, 22L, employerId, "apply");
+        ReflectionTestUtils.setField(application, "id", applicationId, Long.class);
+        JobPosting posting = jobPosting(302L, employerId, Status.ACTIVE, 2, 0);
+
+        Project cancelledProject = Project.create(posting, 22L);
+        cancelledProject.cancel();
+        ReflectionTestUtils.setField(cancelledProject, "id", 778L, Long.class);
+
+        when(userRepository.findById(employerId)).thenReturn(Optional.of(user(Role.EMPLOYER)));
+        when(applicationRepo.findById(applicationId)).thenReturn(Optional.of(application));
+        when(jobPostingRepo.findByIdForUpdate(302L)).thenReturn(Optional.of(posting));
+        when(projectPostingRepo.findByJobPostingIdAndFreelancerId(302L, 22L)).thenReturn(Optional.of(cancelledProject));
+
+        // when
+        Long projectId = matchsService.acceptApplication(employerId, applicationId);
+
+        // then
+        assertEquals(778L, projectId);
+        assertEquals(MatchsStatus.ACCEPTED, application.getStatus());
+        assertEquals(ProjectStatus.IN_PROGRESS, cancelledProject.getStatus());
+        assertEquals(1, posting.getMatchedHeadcount());
+        verify(projectPostingRepo, never()).save(any());
+    }
+
+    @Test
     @DisplayName("[TDD] 지원 수락 시 신규 프로젝트 생성 후 projectId를 반환")
     void acceptApplication_createsProject() {
         // given
@@ -176,6 +207,38 @@ class MatchsServiceImplTest {
     }
 
     @Test
+    @DisplayName("[TDD] 지원 거절 시 취소 상태의 프로젝트 이력을 생성한다")
+    void rejectApplication_createsCancelledProjectHistory() {
+        // given
+        Long employerId = 1L;
+        Long applicationId = 13L;
+        Application application = Application.create(303L, 23L, employerId, "apply");
+        ReflectionTestUtils.setField(application, "id", applicationId, Long.class);
+        JobPosting posting = jobPosting(303L, employerId, Status.ACTIVE, 2, 0);
+
+        when(userRepository.findById(employerId)).thenReturn(Optional.of(user(Role.EMPLOYER)));
+        when(applicationRepo.findById(applicationId)).thenReturn(Optional.of(application));
+        when(jobPostingRepo.findByIdForUpdate(303L)).thenReturn(Optional.of(posting));
+        when(projectPostingRepo.findByJobPostingIdAndFreelancerId(303L, 23L)).thenReturn(Optional.empty());
+        when(projectPostingRepo.save(any())).thenAnswer(invocation -> {
+            Project project = invocation.getArgument(0);
+            ReflectionTestUtils.setField(project, "id", 901L, Long.class);
+            return project;
+        });
+
+        // when
+        Long result = matchsService.rejectApplication(employerId, applicationId);
+
+        // then
+        assertEquals(applicationId, result);
+        assertEquals(MatchsStatus.REJECTED, application.getStatus());
+        ArgumentCaptor<Project> captor = ArgumentCaptor.forClass(Project.class);
+        verify(projectPostingRepo).save(captor.capture());
+        assertEquals(ProjectStatus.CANCELLED, captor.getValue().getStatus());
+        assertEquals(0, posting.getMatchedHeadcount());
+    }
+
+    @Test
     @DisplayName("[TDD] 제안 거절 시 상태가 PENDING이 아니면 INVALID_INPUT_VALUE 예외")
     void rejectProposal_notPending_throws() {
         // given
@@ -192,6 +255,38 @@ class MatchsServiceImplTest {
 
         // then
         assertEquals(ErrorCode.INVALID_INPUT_VALUE, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("[TDD] 제안 거절 시 취소 상태의 프로젝트 이력을 생성한다")
+    void rejectProposal_createsCancelledProjectHistory() {
+        // given
+        Long freelancerId = 33L;
+        Long proposalId = 45L;
+        Proposal proposal = Proposal.create(304L, freelancerId, 77L, "msg");
+        ReflectionTestUtils.setField(proposal, "id", proposalId, Long.class);
+        JobPosting posting = jobPosting(304L, 77L, Status.ACTIVE, 2, 0);
+
+        when(userRepository.findById(freelancerId)).thenReturn(Optional.of(user(Role.FREELANCER)));
+        when(proposalRepo.findById(proposalId)).thenReturn(Optional.of(proposal));
+        when(jobPostingRepo.findByIdForUpdate(304L)).thenReturn(Optional.of(posting));
+        when(projectPostingRepo.findByJobPostingIdAndFreelancerId(304L, freelancerId)).thenReturn(Optional.empty());
+        when(projectPostingRepo.save(any())).thenAnswer(invocation -> {
+            Project project = invocation.getArgument(0);
+            ReflectionTestUtils.setField(project, "id", 902L, Long.class);
+            return project;
+        });
+
+        // when
+        Long result = matchsService.rejectProposal(freelancerId, proposalId);
+
+        // then
+        assertEquals(proposalId, result);
+        assertEquals(MatchsStatus.REJECTED, proposal.getStatus());
+        ArgumentCaptor<Project> captor = ArgumentCaptor.forClass(Project.class);
+        verify(projectPostingRepo).save(captor.capture());
+        assertEquals(ProjectStatus.CANCELLED, captor.getValue().getStatus());
+        assertEquals(0, posting.getMatchedHeadcount());
     }
 
     @Test

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/entity/Project.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/entity/Project.java
@@ -59,4 +59,18 @@ public class Project extends BaseEntity {
         }
         this.status = ProjectStatus.COMPLETED;
     }
+
+    public void cancel() {
+        if (this.status == ProjectStatus.COMPLETED) {
+            return;
+        }
+        this.status = ProjectStatus.CANCELLED;
+    }
+
+    public void reopen() {
+        if (this.status == ProjectStatus.COMPLETED) {
+            throw new IllegalStateException("완료된 프로젝트는 다시 진행할 수 없습니다.");
+        }
+        this.status = ProjectStatus.IN_PROGRESS;
+    }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #이슈번호

## 📝 작업 내용
지원/제안 거절 이력도 `projects` 테이블에 남도록 백엔드 매칭 로직을 수정하고,
동일한 공고-프리랜서 조합이 다시 수락될 경우 기존 이력 프로젝트를 재사용하도록 상태 전이를 보완했습니다.

## ✅ Changes
- `application` 거절 시 `projects`에 `CANCELLED` 상태의 프로젝트 이력이 생성되도록 수정
- `proposal` 거절 시에도 동일하게 `CANCELLED` 프로젝트 이력이 저장되도록 수정
- 동일 공고-프리랜서 조합이 다시 수락되면 기존 `CANCELLED` 프로젝트를 `IN_PROGRESS`로 복구하도록 처리
- `Project` 엔티티에 프로젝트 취소/재진행 상태 메서드 추가
- 지원 수락, 지원 거절, 제안 거절 관련 서비스 테스트 추가

## 📸 스크린샷 (선택)
백엔드 로직 변경 사항으로 별도 스크린샷은 없습니다.

## ⚠️ Notes (Optional)
- `ProjectStatus`에 별도 `REJECTED` 값이 없어 거절 이력은 기존 `CANCELLED` 상태로 관리합니다.
- 이미 `IN_PROGRESS` 또는 `COMPLETED` 상태인 프로젝트가 존재하면 거절 시 새 프로젝트를 중복 생성하지 않습니다.
- 테스트:
  `./gradlew :matchs:test --tests com.fallguys.matchs.service.MatchsServiceImplTest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 지원서 또는 제안 거절 시 프로젝트 이력 기록이 자동으로 생성됩니다.
  * 거절된 프로젝트를 수락할 경우, 기존 프로젝트가 재개되어 새 프로젝트 생성 없이 상태가 복구됩니다.
  * 프로젝트의 취소 및 재개 기능이 추가되었습니다.

* **테스트**
  * 프로젝트 이력 관리 및 상태 전환에 대한 테스트 케이스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->