### PR TITLE
Hfp 74 feat(review): 지원 거절 사유 작성과 사용자별 조회 API 구현

### DIFF
--- a/freebridge/review/src/main/java/com/fallguys/review/api/dto/request/EmployerRejectionReasonCreateRequest.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/api/dto/request/EmployerRejectionReasonCreateRequest.java
@@ -1,0 +1,22 @@
+package com.fallguys.review.api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record EmployerRejectionReasonCreateRequest(
+        @NotNull
+        Long projectId,
+
+        @NotBlank
+        @Size(max = 255)
+        String projectTitle,
+
+        @NotNull
+        Long freelancerId,
+
+        @NotBlank
+        @Size(max = 1000)
+        String reason
+) {
+}

--- a/freebridge/review/src/main/java/com/fallguys/review/api/dto/response/EmployerRejectionReasonResponseDTO.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/api/dto/response/EmployerRejectionReasonResponseDTO.java
@@ -1,0 +1,14 @@
+package com.fallguys.review.api.dto.response;
+
+import java.time.LocalDateTime;
+
+public record EmployerRejectionReasonResponseDTO(
+        Long id,
+        Long projectId,
+        String projectTitle,
+        Long employerId,
+        Long freelancerId,
+        String reason,
+        LocalDateTime createdAt
+) {
+}

--- a/freebridge/review/src/main/java/com/fallguys/review/api/web/EmployerRejectionReasonController.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/api/web/EmployerRejectionReasonController.java
@@ -1,0 +1,69 @@
+package com.fallguys.review.api.web;
+
+import com.fallguys.common.response.ApiResponse;
+import com.fallguys.review.api.dto.request.EmployerRejectionReasonCreateRequest;
+import com.fallguys.review.api.dto.response.EmployerRejectionReasonResponseDTO;
+import com.fallguys.review.api.dto.response.PagedResponseDTO;
+import com.fallguys.review.api.support.ReviewTokenUserIdResolver;
+import com.fallguys.review.service.EmployerRejectionReasonService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("reviewEmployerRejectionReasonController")
+@RequiredArgsConstructor
+@Tag(name = "Review - Employer Rejection Reason", description = "고용주 거절 사유 작성 및 조회 API")
+public class EmployerRejectionReasonController {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final EmployerRejectionReasonService employerRejectionReasonService;
+    private final ReviewTokenUserIdResolver reviewTokenUserIdResolver;
+
+    @Operation(summary = "고용주 거절 사유 작성", description = "고용주가 프리랜서 거절 사유를 저장합니다.")
+    @PostMapping("/api/employer/rejection-reasons")
+    public ResponseEntity<ApiResponse<Long>> createEmployerRejectionReason(
+            @RequestHeader("Authorization") String authorization,
+            @Valid @RequestBody EmployerRejectionReasonCreateRequest request
+    ) {
+        Long employerId = reviewTokenUserIdResolver.resolveUserId(authorization);
+        Long rejectionReasonId = employerRejectionReasonService.createEmployerRejectionReason(employerId, request);
+        return ResponseEntity.ok(ApiResponse.ok(rejectionReasonId));
+    }
+
+    @Operation(summary = "고용주 거절 사유 목록 조회", description = "고용주가 등록한 거절 사유를 전체 조회하거나 프로젝트 제목으로 검색합니다.")
+    @GetMapping("/api/employer/rejection-reasons")
+    public ResponseEntity<ApiResponse<PagedResponseDTO<EmployerRejectionReasonResponseDTO>>> getEmployerRejectionReasons(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam(required = false) String title,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        int safePage = Math.max(0, page);
+        int safeSize = Math.min(Math.max(1, size), MAX_PAGE_SIZE);
+        Long employerId = reviewTokenUserIdResolver.resolveUserId(authorization);
+
+        Page<EmployerRejectionReasonResponseDTO> result = employerRejectionReasonService.getEmployerRejectionReasons(
+                employerId,
+                title,
+                PageRequest.of(safePage, safeSize)
+        );
+        return ResponseEntity.ok(ApiResponse.ok(new PagedResponseDTO<>(
+                result.getContent(),
+                result.getNumber(),
+                result.getSize(),
+                result.getTotalElements(),
+                result.getTotalPages()
+        )));
+    }
+}

--- a/freebridge/review/src/main/java/com/fallguys/review/api/web/FreelancerRejectionReasonController.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/api/web/FreelancerRejectionReasonController.java
@@ -1,0 +1,54 @@
+package com.fallguys.review.api.web;
+
+import com.fallguys.common.response.ApiResponse;
+import com.fallguys.review.api.dto.response.EmployerRejectionReasonResponseDTO;
+import com.fallguys.review.api.dto.response.PagedResponseDTO;
+import com.fallguys.review.api.support.ReviewTokenUserIdResolver;
+import com.fallguys.review.service.EmployerRejectionReasonService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("reviewFreelancerRejectionReasonController")
+@RequiredArgsConstructor
+@Tag(name = "Review - Freelancer Rejection Reason", description = "프리랜서 거절 사유 조회 API")
+public class FreelancerRejectionReasonController {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final EmployerRejectionReasonService employerRejectionReasonService;
+    private final ReviewTokenUserIdResolver reviewTokenUserIdResolver;
+
+    @Operation(summary = "프리랜서 거절 사유 목록 조회", description = "프리랜서가 자신이 거절당한 사유를 전체 조회하거나 프로젝트 제목으로 검색합니다.")
+    @GetMapping("/api/freelancer/rejection-reasons")
+    public ResponseEntity<ApiResponse<PagedResponseDTO<EmployerRejectionReasonResponseDTO>>> getFreelancerRejectionReasons(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam(required = false) String title,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        int safePage = Math.max(0, page);
+        int safeSize = Math.min(Math.max(1, size), MAX_PAGE_SIZE);
+        Long freelancerId = reviewTokenUserIdResolver.resolveUserId(authorization);
+
+        Page<EmployerRejectionReasonResponseDTO> result = employerRejectionReasonService.getFreelancerRejectionReasons(
+                freelancerId,
+                title,
+                PageRequest.of(safePage, safeSize)
+        );
+        return ResponseEntity.ok(ApiResponse.ok(new PagedResponseDTO<>(
+                result.getContent(),
+                result.getNumber(),
+                result.getSize(),
+                result.getTotalElements(),
+                result.getTotalPages()
+        )));
+    }
+}

--- a/freebridge/review/src/main/java/com/fallguys/review/entity/EmployerRejectionReason.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/entity/EmployerRejectionReason.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
@@ -16,7 +17,13 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "employer_rejection_reasons")
+@Table(
+        name = "employer_rejection_reasons",
+        indexes = {
+                @Index(name = "idx_employer_rejection_reason_employer_id", columnList = "employer_id"),
+                @Index(name = "idx_employer_rejection_reason_freelancer_id", columnList = "freelancer_id")
+        }
+)
 @Getter
 @Builder
 @NoArgsConstructor

--- a/freebridge/review/src/main/java/com/fallguys/review/entity/EmployerRejectionReason.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/entity/EmployerRejectionReason.java
@@ -1,0 +1,63 @@
+package com.fallguys.review.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "employer_rejection_reasons")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmployerRejectionReason {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "employer_rejection_reason_id")
+    private Long id;
+
+    @Column(name = "project_id", nullable = false)
+    private Long projectId;
+
+    @Column(name = "project_title", nullable = false)
+    private String projectTitle;
+
+    @Column(name = "employer_id", nullable = false)
+    private Long employerId;
+
+    @Column(name = "freelancer_id", nullable = false)
+    private Long freelancerId;
+
+    @Column(name = "reason", nullable = false, length = 1000)
+    private String reason;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/freebridge/review/src/main/java/com/fallguys/review/repository/EmployerRejectionReasonRepository.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/repository/EmployerRejectionReasonRepository.java
@@ -14,4 +14,12 @@ public interface EmployerRejectionReasonRepository extends JpaRepository<Employe
             String projectTitle,
             Pageable pageable
     );
+
+    Page<EmployerRejectionReason> findAllByFreelancerIdOrderByCreatedAtDesc(Long freelancerId, Pageable pageable);
+
+    Page<EmployerRejectionReason> findAllByFreelancerIdAndProjectTitleContainingIgnoreCaseOrderByCreatedAtDesc(
+            Long freelancerId,
+            String projectTitle,
+            Pageable pageable
+    );
 }

--- a/freebridge/review/src/main/java/com/fallguys/review/repository/EmployerRejectionReasonRepository.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/repository/EmployerRejectionReasonRepository.java
@@ -1,0 +1,17 @@
+package com.fallguys.review.repository;
+
+import com.fallguys.review.entity.EmployerRejectionReason;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmployerRejectionReasonRepository extends JpaRepository<EmployerRejectionReason, Long> {
+
+    Page<EmployerRejectionReason> findAllByEmployerIdOrderByCreatedAtDesc(Long employerId, Pageable pageable);
+
+    Page<EmployerRejectionReason> findAllByEmployerIdAndProjectTitleContainingIgnoreCaseOrderByCreatedAtDesc(
+            Long employerId,
+            String projectTitle,
+            Pageable pageable
+    );
+}

--- a/freebridge/review/src/main/java/com/fallguys/review/service/EmployerRejectionReasonService.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/service/EmployerRejectionReasonService.java
@@ -1,0 +1,13 @@
+package com.fallguys.review.service;
+
+import com.fallguys.review.api.dto.request.EmployerRejectionReasonCreateRequest;
+import com.fallguys.review.api.dto.response.EmployerRejectionReasonResponseDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface EmployerRejectionReasonService {
+
+    Long createEmployerRejectionReason(Long employerId, EmployerRejectionReasonCreateRequest request);
+
+    Page<EmployerRejectionReasonResponseDTO> getEmployerRejectionReasons(Long employerId, String title, Pageable pageable);
+}

--- a/freebridge/review/src/main/java/com/fallguys/review/service/EmployerRejectionReasonService.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/service/EmployerRejectionReasonService.java
@@ -10,4 +10,6 @@ public interface EmployerRejectionReasonService {
     Long createEmployerRejectionReason(Long employerId, EmployerRejectionReasonCreateRequest request);
 
     Page<EmployerRejectionReasonResponseDTO> getEmployerRejectionReasons(Long employerId, String title, Pageable pageable);
+
+    Page<EmployerRejectionReasonResponseDTO> getFreelancerRejectionReasons(Long freelancerId, String title, Pageable pageable);
 }

--- a/freebridge/review/src/main/java/com/fallguys/review/service/EmployerRejectionReasonServiceImpl.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/service/EmployerRejectionReasonServiceImpl.java
@@ -45,6 +45,20 @@ public class EmployerRejectionReasonServiceImpl implements EmployerRejectionReas
         return result.map(this::toResponse);
     }
 
+    @Override
+    public Page<EmployerRejectionReasonResponseDTO> getFreelancerRejectionReasons(Long freelancerId, String title, Pageable pageable) {
+        String normalizedTitle = normalizeTitle(title);
+        Page<EmployerRejectionReason> result = StringUtils.hasText(normalizedTitle)
+                ? employerRejectionReasonRepository.findAllByFreelancerIdAndProjectTitleContainingIgnoreCaseOrderByCreatedAtDesc(
+                freelancerId,
+                normalizedTitle,
+                pageable
+        )
+                : employerRejectionReasonRepository.findAllByFreelancerIdOrderByCreatedAtDesc(freelancerId, pageable);
+
+        return result.map(this::toResponse);
+    }
+
     private EmployerRejectionReasonResponseDTO toResponse(EmployerRejectionReason rejectionReason) {
         return new EmployerRejectionReasonResponseDTO(
                 rejectionReason.getId(),

--- a/freebridge/review/src/main/java/com/fallguys/review/service/EmployerRejectionReasonServiceImpl.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/service/EmployerRejectionReasonServiceImpl.java
@@ -1,0 +1,66 @@
+package com.fallguys.review.service;
+
+import com.fallguys.review.api.dto.request.EmployerRejectionReasonCreateRequest;
+import com.fallguys.review.api.dto.response.EmployerRejectionReasonResponseDTO;
+import com.fallguys.review.entity.EmployerRejectionReason;
+import com.fallguys.review.repository.EmployerRejectionReasonRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EmployerRejectionReasonServiceImpl implements EmployerRejectionReasonService {
+
+    private final EmployerRejectionReasonRepository employerRejectionReasonRepository;
+
+    @Override
+    @Transactional
+    public Long createEmployerRejectionReason(Long employerId, EmployerRejectionReasonCreateRequest request) {
+        EmployerRejectionReason reason = EmployerRejectionReason.builder()
+                .projectId(request.projectId())
+                .projectTitle(request.projectTitle().trim())
+                .employerId(employerId)
+                .freelancerId(request.freelancerId())
+                .reason(request.reason().trim())
+                .build();
+        return employerRejectionReasonRepository.save(reason).getId();
+    }
+
+    @Override
+    public Page<EmployerRejectionReasonResponseDTO> getEmployerRejectionReasons(Long employerId, String title, Pageable pageable) {
+        String normalizedTitle = normalizeTitle(title);
+        Page<EmployerRejectionReason> result = StringUtils.hasText(normalizedTitle)
+                ? employerRejectionReasonRepository.findAllByEmployerIdAndProjectTitleContainingIgnoreCaseOrderByCreatedAtDesc(
+                employerId,
+                normalizedTitle,
+                pageable
+        )
+                : employerRejectionReasonRepository.findAllByEmployerIdOrderByCreatedAtDesc(employerId, pageable);
+
+        return result.map(this::toResponse);
+    }
+
+    private EmployerRejectionReasonResponseDTO toResponse(EmployerRejectionReason rejectionReason) {
+        return new EmployerRejectionReasonResponseDTO(
+                rejectionReason.getId(),
+                rejectionReason.getProjectId(),
+                rejectionReason.getProjectTitle(),
+                rejectionReason.getEmployerId(),
+                rejectionReason.getFreelancerId(),
+                rejectionReason.getReason(),
+                rejectionReason.getCreatedAt()
+        );
+    }
+
+    private String normalizeTitle(String title) {
+        if (!StringUtils.hasText(title)) {
+            return null;
+        }
+        return title.trim();
+    }
+}

--- a/freebridge/review/src/test/java/com/fallguys/review/api/web/EmployerRejectionReasonControllerTest.java
+++ b/freebridge/review/src/test/java/com/fallguys/review/api/web/EmployerRejectionReasonControllerTest.java
@@ -1,0 +1,89 @@
+package com.fallguys.review.api.web;
+
+import com.fallguys.common.response.ApiResponse;
+import com.fallguys.review.api.dto.request.EmployerRejectionReasonCreateRequest;
+import com.fallguys.review.api.dto.response.EmployerRejectionReasonResponseDTO;
+import com.fallguys.review.api.support.ReviewTokenUserIdResolver;
+import com.fallguys.review.service.EmployerRejectionReasonService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EmployerRejectionReasonControllerTest {
+
+    @Mock
+    private EmployerRejectionReasonService employerRejectionReasonService;
+
+    @Mock
+    private ReviewTokenUserIdResolver reviewTokenUserIdResolver;
+
+    @InjectMocks
+    private EmployerRejectionReasonController controller;
+
+    @Test
+    @DisplayName("[TDD] 고용주 거절 사유 생성 시 토큰의 사용자 ID로 저장 요청을 전달한다")
+    void createEmployerRejectionReason_callsService() {
+        // given
+        String authorization = "Bearer token";
+        Long employerId = 11L;
+        EmployerRejectionReasonCreateRequest request = new EmployerRejectionReasonCreateRequest(
+                7L,
+                "플랫폼 구축",
+                22L,
+                "기술 스택이 맞지 않음"
+        );
+        when(reviewTokenUserIdResolver.resolveUserId(authorization)).thenReturn(employerId);
+        when(employerRejectionReasonService.createEmployerRejectionReason(employerId, request)).thenReturn(101L);
+
+        // when
+        ResponseEntity<ApiResponse<Long>> response = controller.createEmployerRejectionReason(authorization, request);
+
+        // then
+        verify(employerRejectionReasonService, times(1)).createEmployerRejectionReason(employerId, request);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(101L, response.getBody().data());
+    }
+
+    @Test
+    @DisplayName("[TDD] 고용주 거절 사유 조회 시 page/size를 안전값으로 보정하고 제목 검색어를 전달한다")
+    void getEmployerRejectionReasons_clampsPageAndSize() {
+        // given
+        String authorization = "Bearer token";
+        when(reviewTokenUserIdResolver.resolveUserId(authorization)).thenReturn(1L);
+        Page<EmployerRejectionReasonResponseDTO> page = new PageImpl<>(List.of(
+                new EmployerRejectionReasonResponseDTO(1L, 10L, "결제 모듈", 1L, 2L, "사유", LocalDateTime.now())
+        ));
+        when(employerRejectionReasonService.getEmployerRejectionReasons(org.mockito.ArgumentMatchers.eq(1L), org.mockito.ArgumentMatchers.eq("결제"), org.mockito.ArgumentMatchers.any()))
+                .thenReturn(page);
+
+        // when
+        controller.getEmployerRejectionReasons(authorization, "결제", -1, 1000);
+
+        // then
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(employerRejectionReasonService, times(1))
+                .getEmployerRejectionReasons(org.mockito.ArgumentMatchers.eq(1L), org.mockito.ArgumentMatchers.eq("결제"), pageableCaptor.capture());
+        assertEquals(0, pageableCaptor.getValue().getPageNumber());
+        assertEquals(100, pageableCaptor.getValue().getPageSize());
+    }
+}

--- a/freebridge/review/src/test/java/com/fallguys/review/api/web/FreelancerRejectionReasonControllerTest.java
+++ b/freebridge/review/src/test/java/com/fallguys/review/api/web/FreelancerRejectionReasonControllerTest.java
@@ -1,0 +1,70 @@
+package com.fallguys.review.api.web;
+
+import com.fallguys.common.response.ApiResponse;
+import com.fallguys.review.api.dto.response.EmployerRejectionReasonResponseDTO;
+import com.fallguys.review.api.support.ReviewTokenUserIdResolver;
+import com.fallguys.review.service.EmployerRejectionReasonService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FreelancerRejectionReasonControllerTest {
+
+    @Mock
+    private EmployerRejectionReasonService employerRejectionReasonService;
+
+    @Mock
+    private ReviewTokenUserIdResolver reviewTokenUserIdResolver;
+
+    @InjectMocks
+    private FreelancerRejectionReasonController controller;
+
+    @Test
+    @DisplayName("[TDD] 프리랜서 거절 사유 조회 시 page/size를 안전값으로 보정해 서비스에 전달한다")
+    void getFreelancerRejectionReasons_clampsPageAndSize() {
+        // given
+        String authorization = "Bearer token";
+        when(reviewTokenUserIdResolver.resolveUserId(authorization)).thenReturn(31L);
+        Page<EmployerRejectionReasonResponseDTO> page = new PageImpl<>(List.of(
+                new EmployerRejectionReasonResponseDTO(1L, 10L, "플랫폼 구축", 1L, 31L, "사유", LocalDateTime.now())
+        ));
+        when(employerRejectionReasonService.getFreelancerRejectionReasons(
+                org.mockito.ArgumentMatchers.eq(31L),
+                org.mockito.ArgumentMatchers.eq("플랫폼"),
+                org.mockito.ArgumentMatchers.any()
+        )).thenReturn(page);
+
+        // when
+        ResponseEntity<ApiResponse<com.fallguys.review.api.dto.response.PagedResponseDTO<EmployerRejectionReasonResponseDTO>>> response =
+                controller.getFreelancerRejectionReasons(authorization, "플랫폼", -3, 500);
+
+        // then
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(employerRejectionReasonService, times(1))
+                .getFreelancerRejectionReasons(org.mockito.ArgumentMatchers.eq(31L), org.mockito.ArgumentMatchers.eq("플랫폼"), pageableCaptor.capture());
+        assertEquals(0, pageableCaptor.getValue().getPageNumber());
+        assertEquals(100, pageableCaptor.getValue().getPageSize());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(1, response.getBody().data().totalElements());
+    }
+}

--- a/freebridge/review/src/test/java/com/fallguys/review/service/EmployerRejectionReasonServiceImplTest.java
+++ b/freebridge/review/src/test/java/com/fallguys/review/service/EmployerRejectionReasonServiceImplTest.java
@@ -1,0 +1,99 @@
+package com.fallguys.review.service;
+
+import com.fallguys.review.api.dto.request.EmployerRejectionReasonCreateRequest;
+import com.fallguys.review.api.dto.response.EmployerRejectionReasonResponseDTO;
+import com.fallguys.review.entity.EmployerRejectionReason;
+import com.fallguys.review.repository.EmployerRejectionReasonRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EmployerRejectionReasonServiceImplTest {
+
+    @Mock
+    private EmployerRejectionReasonRepository employerRejectionReasonRepository;
+
+    @InjectMocks
+    private EmployerRejectionReasonServiceImpl employerRejectionReasonService;
+
+    @Test
+    @DisplayName("[TDD] 고용주 거절 사유 생성 시 employerId를 포함해 저장한다")
+    void createEmployerRejectionReason_savesReason() {
+        // given
+        Long employerId = 1L;
+        EmployerRejectionReasonCreateRequest request = new EmployerRejectionReasonCreateRequest(
+                10L,
+                "  프리브릿지 플랫폼 구축  ",
+                20L,
+                "  포트폴리오와 요구사항이 맞지 않았습니다.  "
+        );
+        when(employerRejectionReasonRepository.save(any())).thenAnswer(invocation -> {
+            EmployerRejectionReason rejectionReason = invocation.getArgument(0);
+            ReflectionTestUtils.setField(rejectionReason, "id", 100L, Long.class);
+            return rejectionReason;
+        });
+
+        // when
+        Long savedId = employerRejectionReasonService.createEmployerRejectionReason(employerId, request);
+
+        // then
+        assertEquals(100L, savedId);
+        ArgumentCaptor<EmployerRejectionReason> captor = ArgumentCaptor.forClass(EmployerRejectionReason.class);
+        verify(employerRejectionReasonRepository, times(1)).save(captor.capture());
+        assertEquals(employerId, captor.getValue().getEmployerId());
+        assertEquals("프리브릿지 플랫폼 구축", captor.getValue().getProjectTitle());
+        assertEquals("포트폴리오와 요구사항이 맞지 않았습니다.", captor.getValue().getReason());
+    }
+
+    @Test
+    @DisplayName("[TDD] 프로젝트 제목 검색어가 있으면 제목 필터 조회를 수행한다")
+    void getEmployerRejectionReasons_withTitle_usesFilteredQuery() {
+        // given
+        Long employerId = 2L;
+        PageRequest pageable = PageRequest.of(0, 10);
+        EmployerRejectionReason rejectionReason = EmployerRejectionReason.builder()
+                .id(1L)
+                .projectId(10L)
+                .projectTitle("결제 모듈 테스트")
+                .employerId(employerId)
+                .freelancerId(30L)
+                .reason("요구 기술과 맞지 않음")
+                .build();
+        ReflectionTestUtils.setField(rejectionReason, "createdAt", java.time.LocalDateTime.of(2026, 3, 11, 10, 0));
+        when(employerRejectionReasonRepository.findAllByEmployerIdAndProjectTitleContainingIgnoreCaseOrderByCreatedAtDesc(
+                employerId,
+                "결제",
+                pageable
+        )).thenReturn(new PageImpl<>(List.of(rejectionReason), pageable, 1));
+
+        // when
+        Page<EmployerRejectionReasonResponseDTO> result = employerRejectionReasonService.getEmployerRejectionReasons(
+                employerId,
+                "  결제  ",
+                pageable
+        );
+
+        // then
+        assertEquals(1, result.getTotalElements());
+        assertEquals("결제 모듈 테스트", result.getContent().get(0).projectTitle());
+        verify(employerRejectionReasonRepository, times(1))
+                .findAllByEmployerIdAndProjectTitleContainingIgnoreCaseOrderByCreatedAtDesc(employerId, "결제", pageable);
+    }
+}

--- a/freebridge/review/src/test/java/com/fallguys/review/service/EmployerRejectionReasonServiceImplTest.java
+++ b/freebridge/review/src/test/java/com/fallguys/review/service/EmployerRejectionReasonServiceImplTest.java
@@ -96,4 +96,39 @@ class EmployerRejectionReasonServiceImplTest {
         verify(employerRejectionReasonRepository, times(1))
                 .findAllByEmployerIdAndProjectTitleContainingIgnoreCaseOrderByCreatedAtDesc(employerId, "결제", pageable);
     }
+
+    @Test
+    @DisplayName("[TDD] 프리랜서 거절 사유 조회 시 freelancerId 기준 목록을 반환한다")
+    void getFreelancerRejectionReasons_usesFreelancerQuery() {
+        // given
+        Long freelancerId = 30L;
+        PageRequest pageable = PageRequest.of(0, 10);
+        EmployerRejectionReason rejectionReason = EmployerRejectionReason.builder()
+                .id(2L)
+                .projectId(20L)
+                .projectTitle("플랫폼 구축")
+                .employerId(4L)
+                .freelancerId(freelancerId)
+                .reason("현재 요구 경력과 차이가 있습니다.")
+                .build();
+        ReflectionTestUtils.setField(rejectionReason, "createdAt", java.time.LocalDateTime.of(2026, 3, 11, 12, 0));
+        when(employerRejectionReasonRepository.findAllByFreelancerIdOrderByCreatedAtDesc(
+                freelancerId,
+                pageable
+        )).thenReturn(new PageImpl<>(List.of(rejectionReason), pageable, 1));
+
+        // when
+        Page<EmployerRejectionReasonResponseDTO> result = employerRejectionReasonService.getFreelancerRejectionReasons(
+                freelancerId,
+                null,
+                pageable
+        );
+
+        // then
+        assertEquals(1, result.getTotalElements());
+        assertEquals("플랫폼 구축", result.getContent().get(0).projectTitle());
+        assertEquals("현재 요구 경력과 차이가 있습니다.", result.getContent().get(0).reason());
+        verify(employerRejectionReasonRepository, times(1))
+                .findAllByFreelancerIdOrderByCreatedAtDesc(freelancerId, pageable);
+    }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #이슈번호

## 📝 작업 내용
고용주가 프리랜서 지원/제안을 거절할 때 사유를 저장할 수 있도록 API를 추가하고,
고용주와 프리랜서가 각각 자신의 거절 사유 이력을 조회할 수 있는 기능을 구현했습니다.

## ✅ Changes
- 고용주 거절 사유 저장 API `POST /api/employer/rejection-reasons` 추가
- 고용주 거절 사유 전체 조회/제목 검색 API `GET /api/employer/rejection-reasons` 추가
- 프리랜서 거절 사유 전체 조회/제목 검색 API `GET /api/freelancer/rejection-reasons` 추가
- 거절 사유 저장용 엔티티, DTO, 리포지토리, 서비스 계층 구현
- 제목 검색과 사용자별 조회가 가능하도록 페이징 조회 로직 추가
- 고용주/프리랜서 조회 및 저장 관련 컨트롤러/서비스 테스트 추가

## 📸 스크린샷 (선택)
백엔드 API 추가 작업으로 별도 스크린샷은 없습니다.

## ⚠️ Notes (Optional)
- 거절 사유 조회는 JWT 기반으로 현재 로그인한 사용자 ID를 추출해 고용주/프리랜서별로 분리 조회합니다.
- 프론트에서는 고용주가 거절 시 저장 API를 호출하고, 프리랜서는 조회 API로 자신의 거절 사유를 확인할 수 있습니다.
- 관련 API:
  - `POST /api/employer/rejection-reasons`
  - `GET /api/employer/rejection-reasons`
  - `GET /api/freelancer/rejection-reasons`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 고용주가 프로젝트 거절 사유를 생성하고 관리할 수 있는 기능이 추가되었습니다.
  * 고용주는 거절 사유를 조회하고 프로젝트 제목으로 필터링할 수 있습니다.
  * 프리랜서는 자신에게 접수된 거절 사유를 조회하고 필터링할 수 있습니다.
  * 페이지네이션 지원으로 대량의 데이터를 효율적으로 관리할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->