### PR TITLE
HFP-74 fix: 채용공고 duration 의미 정리 및 deadline 제거

### DIFF
--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
@@ -433,11 +433,8 @@ public class MatchsServiceImpl implements MatchsService {
             item.put("applicantCount", applicantCountsByPostingId.getOrDefault(posting.getId(), 0));
             item.put("createdAt", formatIsoSeconds(posting.getCreatedAt()));
 
-            LocalDateTime deadline = posting.getCreatedAt();
-            if (posting.getDuration() != null && posting.getDuration() > 0) {
-                deadline = deadline.plusDays(posting.getDuration());
-            }
-            item.put("deadline", formatIsoSeconds(deadline));
+            // Job posting duration is an estimated project period in months, not a recruitment deadline.
+            item.put("deadline", null);
             payload.add(item);
         }
 

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/request/JobPostingCreateDTO.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/request/JobPostingCreateDTO.java
@@ -1,6 +1,8 @@
 package com.fallguys.recruitment.api.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
@@ -9,6 +11,8 @@ public record JobPostingCreateDTO(
         String description,
         List<String> techStack,
         Long budget,
+        @NotNull
+        @Min(1)
         @Schema(description = "예상 프로젝트 기간(개월 수)", example = "3")
         Integer duration,
         Integer headcount

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/request/JobPostingCreateDTO.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/request/JobPostingCreateDTO.java
@@ -1,4 +1,7 @@
 package com.fallguys.recruitment.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record JobPostingCreateDTO(
@@ -6,6 +9,7 @@ public record JobPostingCreateDTO(
         String description,
         List<String> techStack,
         Long budget,
+        @Schema(description = "예상 프로젝트 기간(개월 수)", example = "3")
         Integer duration,
         Integer headcount
 ) {}

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/request/JobPostingUpdateDTO.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/request/JobPostingUpdateDTO.java
@@ -1,6 +1,7 @@
 package com.fallguys.recruitment.api.dto.request;
 
 import com.fallguys.recruitment.entity.JobPostingStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 public record JobPostingUpdateDTO(
@@ -8,6 +9,7 @@ public record JobPostingUpdateDTO(
         String description,
         List<String> techStack,
         Long budget,
+        @Schema(description = "예상 프로젝트 기간(개월 수)", example = "3")
         Integer duration,
         Integer headcount,
         JobPostingStatus status

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/response/FreelancerJobPostingSearchDTO.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/response/FreelancerJobPostingSearchDTO.java
@@ -1,5 +1,7 @@
 package com.fallguys.recruitment.api.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record FreelancerJobPostingSearchDTO(
@@ -9,6 +11,7 @@ public record FreelancerJobPostingSearchDTO(
         String description,
         List<String> techStack,
         Long budget,
+        @Schema(description = "예상 프로젝트 기간(개월 수)", example = "3")
         Integer duration,
         Integer headcount,
         Integer matchedHeadcount,

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/response/JobPostingSearchDTO.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/api/dto/response/JobPostingSearchDTO.java
@@ -1,6 +1,7 @@
 package com.fallguys.recruitment.api.dto.response;
 
 import com.fallguys.recruitment.entity.JobPostingStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
@@ -11,6 +12,7 @@ public record JobPostingSearchDTO(
         String description,
         List<String> techStack,
         Long budget,
+        @Schema(description = "예상 프로젝트 기간(개월 수)", example = "3")
         Integer duration,
         Integer headcount,
         Integer matchedHeadcount,

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/entity/JobPosting.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/entity/JobPosting.java
@@ -35,6 +35,7 @@ public class JobPosting extends BaseEntity {
     private Long budget;
 
     @Column(nullable = false)
+    // Expected project duration in months entered while creating the job posting.
     private Integer duration;
 
     @Column(name = "headcount", nullable = false)

--- a/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
+++ b/freebridge/recruitment/src/main/java/com/fallguys/recruitment/service/JobPostingServiceImpl.java
@@ -770,11 +770,8 @@ public class JobPostingServiceImpl implements JobPostingService {
         LocalDateTime createdAt = posting.getCreatedAt();
         item.put("createdAt", createdAt != null ? createdAt.format(ISO_SECONDS_FORMATTER) : null);
 
-        LocalDateTime deadline = createdAt;
-        if (createdAt != null && posting.getDuration() != null && posting.getDuration() > 0) {
-            deadline = createdAt.plusDays(posting.getDuration());
-        }
-        item.put("deadline", deadline != null ? deadline.format(ISO_SECONDS_FORMATTER) : null);
+        // Job posting duration is an estimated project period in months, not a recruitment deadline.
+        item.put("deadline", null);
         return item;
     }
 


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #

## 📝 작업 내용
채용공고의 `duration` 필드 의미를 `예상 프로젝트 기간(개월 수)`로 정리하고, 해당 값을 일 단위 `deadline` 계산에 사용하던 로직을 제거했습니다.

## ✅ Changes
- 채용공고 `duration`의 의미를 예상 기간(개월 수)로 명확화
- 공고 생성/수정/조회 DTO에 `duration` 설명 추가
- `JobPosting` 엔티티에 `duration` 의미 주석 추가
- 고용주 프로젝트 목록/매칭 서비스에서 `duration` 기반 `deadline` 계산 제거
- `deadline` 값이 필요 없는 현재 정책에 맞게 `null` 반환하도록 정리

## 📸 스크린샷 (선택)
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
- 현재 구조에서 실제 프로젝트 기간은 계약서의 `startDate`, `endDate`를 기준으로 관리합니다.
- `Project.startDate/endDate` 연동은 이번 PR 범위에서 제외했습니다.
- 프론트에서 `deadline` 값이 `null`일 수 있으므로 null 처리 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * 프로젝트 기간 필드가 "예상 프로젝트 기간(개월 수)"으로 명확히 정의되고 API 설명이 추가되었습니다.
* **변경 사항**
  * 모집 마감일 계산 로직이 제거되어 관련 필드는 null로 반환됩니다.
  * 채용 공고 생성/수정 시 기간 필드가 필수화되고(최소값 1) 유효성 제약이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->