### PR TITLE
HFP-74 fix: 제안 모달에서 중복 제안 공고를 제외하고 에러 메시지 처리 개선

### DIFF
--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/entity/Application.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/entity/Application.java
@@ -11,7 +11,13 @@ import java.time.LocalDateTime;
 
 //프리랜서->기업
 @Entity
-@Table(name="application")
+@Table(
+        name = "application",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_application_job_posting_freelancer",
+                columnNames = {"job_posting_id", "freelancer_id"}
+        )
+)
 @Getter
 @Builder
 @NoArgsConstructor

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/entity/Proposal.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/entity/Proposal.java
@@ -6,7 +6,13 @@ import java.time.LocalDateTime;
 
 //기업->프리랜서
 @Entity
-@Table(name="Proposal")
+@Table(
+        name = "Proposal",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_proposal_job_posting_freelancer",
+                columnNames = {"job_posting_id", "freelancer_id"}
+        )
+)
 @Builder
 @Getter
 @NoArgsConstructor

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ApplicationRepo.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ApplicationRepo.java
@@ -17,6 +17,8 @@ public interface ApplicationRepo extends JpaRepository<Application,Long> {
 
     Page<Application> findAllByFreelancerIdOrderByCreatedAtDesc(Long freelancerId, Pageable pageable);
 
+    boolean existsByJobPostingIdAndFreelancerId(Long jobPostingId, Long freelancerId);
+
     List<Application> findAllByJobPostingIdOrderByCreatedAtDesc(Long jobPostingId);
 
     long countByJobPostingId(Long jobPostingId);

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ProposalRepo.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/repository/ProposalRepo.java
@@ -12,5 +12,7 @@ public interface ProposalRepo extends JpaRepository<Proposal,Long> {
 
     Page<Proposal> findAllByFreelancerIdOrderByCreatedAtDesc(Long freelancerId, Pageable pageable);
 
+    boolean existsByJobPostingIdAndFreelancerId(Long jobPostingId, Long freelancerId);
+
     long countByFreelancerId(Long freelancerId);
 }

--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
@@ -22,6 +22,7 @@ import com.fallguys.recruitment.service.JobPostingService;
 import com.fallguys.user.entity.Role;
 import com.fallguys.user.entity.User;
 import com.fallguys.user.repository.UserRepository;
+import org.springframework.dao.DataIntegrityViolationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -72,6 +73,7 @@ public class MatchsServiceImpl implements MatchsService {
     public Long createApplication(Long freelancerId, ApplicationCreateRequest request) {
         getUserByRoleOrThrow(freelancerId, Role.FREELANCER);
         JobPosting jobPosting = getOpenJobPostingOrThrow(request.jobPostingId());
+        validateNoDuplicateApplication(request.jobPostingId(), freelancerId);
 
         Application application = Application.create(
                 jobPosting.getId(),
@@ -80,7 +82,7 @@ public class MatchsServiceImpl implements MatchsService {
                 request.message()
         );
 
-        Long applicationId = applicationRepo.save(application).getId();
+        Long applicationId = saveApplication(application).getId();
         runAfterCommitSafely(() -> {
             refreshEmployerProjectStats(jobPosting.getEmployerId());
             refreshEmployerProjectList(jobPosting.getEmployerId());
@@ -101,6 +103,7 @@ public class MatchsServiceImpl implements MatchsService {
         if (!jobPosting.getEmployerId().equals(employerId)) {
             throw new BusinessException(ErrorCode.JOB_POSTING_FORBIDDEN);
         }
+        validateNoDuplicateProposal(request.jobPostingId(), request.freelancerId());
 
         Proposal proposal = Proposal.create(
                 request.jobPostingId(),
@@ -109,7 +112,7 @@ public class MatchsServiceImpl implements MatchsService {
                 request.message()
         );
 
-        Long proposalId = proposalRepo.save(proposal).getId();
+        Long proposalId = saveProposal(proposal).getId();
         runAfterCommitSafely(() -> {
             refreshEmployerProjectStats(employerId);
             refreshEmployerProjectList(employerId);
@@ -328,6 +331,38 @@ public class MatchsServiceImpl implements MatchsService {
     private JobPosting getJobPostingForProjectHistoryOrThrow(Long jobPostingId) {
         return jobPostingRepo.findByIdForUpdate(jobPostingId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.JOB_POSTING_NOT_FOUND));
+    }
+
+    private void validateNoDuplicateApplication(Long jobPostingId, Long freelancerId) {
+        if (applicationRepo.existsByJobPostingIdAndFreelancerId(jobPostingId, freelancerId)) {
+            throw duplicateMatchRequest();
+        }
+    }
+
+    private void validateNoDuplicateProposal(Long jobPostingId, Long freelancerId) {
+        if (proposalRepo.existsByJobPostingIdAndFreelancerId(jobPostingId, freelancerId)) {
+            throw duplicateMatchRequest();
+        }
+    }
+
+    private Application saveApplication(Application application) {
+        try {
+            return applicationRepo.save(application);
+        } catch (DataIntegrityViolationException e) {
+            throw duplicateMatchRequest();
+        }
+    }
+
+    private Proposal saveProposal(Proposal proposal) {
+        try {
+            return proposalRepo.save(proposal);
+        } catch (DataIntegrityViolationException e) {
+            throw duplicateMatchRequest();
+        }
+    }
+
+    private BusinessException duplicateMatchRequest() {
+        return new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
     }
 
     private User getUserByRoleOrThrow(Long userId, Role role) {

--- a/freebridge/matchs/src/test/java/com/fallguys/matchs/service/MatchsServiceImplTest.java
+++ b/freebridge/matchs/src/test/java/com/fallguys/matchs/service/MatchsServiceImplTest.java
@@ -103,6 +103,28 @@ class MatchsServiceImplTest {
     }
 
     @Test
+    @DisplayName("[TDD] 동일한 공고에 중복 지원하면 INVALID_INPUT_VALUE 예외")
+    void createApplication_duplicate_throws() {
+        // given
+        Long freelancerId = 10L;
+        Long jobPostingId = 100L;
+        when(userRepository.findById(freelancerId)).thenReturn(Optional.of(user(Role.FREELANCER)));
+        when(jobPostingRepo.findById(jobPostingId))
+                .thenReturn(Optional.of(jobPosting(jobPostingId, 88L, Status.ACTIVE, 2, 0)));
+        when(applicationRepo.existsByJobPostingIdAndFreelancerId(jobPostingId, freelancerId)).thenReturn(true);
+
+        // when
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> matchsService.createApplication(freelancerId, new ApplicationCreateRequest(jobPostingId, "hello"))
+        );
+
+        // then
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, ex.getErrorCode());
+        verify(applicationRepo, never()).save(any());
+    }
+
+    @Test
     @DisplayName("[TDD] 제안 생성 시 고용주가 공고 소유자가 아니면 JOB_POSTING_FORBIDDEN 예외")
     void createProposal_notOwner_throws() {
         // given
@@ -118,6 +140,30 @@ class MatchsServiceImplTest {
 
         // then
         assertEquals(ErrorCode.JOB_POSTING_FORBIDDEN, ex.getErrorCode());
+        verify(proposalRepo, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("[TDD] 동일한 공고에 중복 제안하면 INVALID_INPUT_VALUE 예외")
+    void createProposal_duplicate_throws() {
+        // given
+        Long employerId = 2L;
+        ProposalCreateRequest request = new ProposalCreateRequest(200L, 3L, "msg");
+        when(userRepository.findById(employerId)).thenReturn(Optional.of(user(Role.EMPLOYER)));
+        when(userRepository.findById(request.freelancerId())).thenReturn(Optional.of(user(Role.FREELANCER)));
+        when(jobPostingRepo.findById(request.jobPostingId()))
+                .thenReturn(Optional.of(jobPosting(200L, employerId, Status.ACTIVE, 2, 0)));
+        when(proposalRepo.existsByJobPostingIdAndFreelancerId(request.jobPostingId(), request.freelancerId()))
+                .thenReturn(true);
+
+        // when
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> matchsService.createProposal(employerId, request)
+        );
+
+        // then
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, ex.getErrorCode());
         verify(proposalRepo, never()).save(any());
     }
 


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #

## 📝 작업 내용
매칭 모듈에서 프리랜서의 동일 공고 중복 지원과 고용주의 동일 공고 중복 제안이 생성되지 않도록 백엔드 검증을 추가했습니다.

## ✅ Changes
- `ApplicationRepo`에 동일 `jobPostingId + freelancerId` 조합 존재 여부 조회 추가
- `ProposalRepo`에 동일 `jobPostingId + freelancerId` 조합 존재 여부 조회 추가
- 지원 생성 시 동일 공고 중복 지원이면 예외를 반환하도록 서비스 검증 추가
- 제안 생성 시 동일 공고 중복 제안이면 예외를 반환하도록 서비스 검증 추가
- 저장 경합 상황에서도 중복 저장이 막히도록 `Application`, `Proposal` 엔티티에 unique constraint 추가
- 중복 지원/제안 예외 케이스에 대한 서비스 테스트 추가

## 📸 스크린샷 (선택)
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
- 현재 중복 요청 예외는 기존 에러 체계에 맞춰 `INVALID_INPUT_VALUE`로 처리했습니다.
- DB에 이미 동일 `jobPostingId + freelancerId` 중복 데이터가 있으면 unique constraint 적용 시 충돌할 수 있어 사전 데이터 확인이 필요합니다.
- 검증은 `./gradlew :matchs:test --tests com.fallguys.matchs.service.MatchsServiceImplTest`와 `./gradlew :matchs:compileJava`로 확인했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 동일한 직무 공고에 대한 중복 지원 및 제안 방지 기능 추가
  * 중복 매칭 요청 시 명확한 오류 메시지 제공

* **테스트**
  * 중복 지원/제안 시나리오에 대한 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->