### PR TITLE
HFP-96 fix: 프리랜서 리뷰 Redis 평점 포맷을 항목별 평균 객체로 변경

### DIFF
--- a/freebridge/review/src/main/java/com/fallguys/review/service/ReviewServiceImpl.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/service/ReviewServiceImpl.java
@@ -279,16 +279,19 @@ public class ReviewServiceImpl implements ReviewService {
 
     private void refreshFreelancerReviewRates(Long freelancerId) {
         List<EmployerReview> reviews = orEmpty(employerReviewRepository.findAllByFreelancerIdAndStatus(freelancerId, ReviewStatus.ACTIVE));
-        List<Map<String, Object>> payload = new ArrayList<>(reviews.size());
-        for (EmployerReview review : reviews) {
-            Map<String, Object> item = new HashMap<>();
-            item.put("expertiseRate", average(review.getLanguage(), review.getFramework(), review.getDebugging()));
-            item.put("communicationRate", toNumberOrZero(review.getCommunication()));
-            item.put("scheduleRate", toNumberOrZero(review.getSchedule()));
-            payload.add(item);
+        if (reviews.isEmpty()) {
+            deleteRedisValue(FREELANCER_REVIEW_RATES_KEY_PREFIX + freelancerId);
+        } else {
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("programming", round1(average(reviews, EmployerReview::getLanguage)));
+            payload.put("framework", round1(average(reviews, EmployerReview::getFramework)));
+            payload.put("debugging", round1(average(reviews, EmployerReview::getDebugging)));
+            payload.put("communication", round1(average(reviews, EmployerReview::getCommunication)));
+            payload.put("schedule", round1(average(reviews, EmployerReview::getSchedule)));
+            payload.put("dispute", round1(average(reviews, EmployerReview::getDispute)));
+            writeRedisValue(FREELANCER_REVIEW_RATES_KEY_PREFIX + freelancerId, payload);
         }
-        writeRedisValue(FREELANCER_REVIEW_RATES_KEY_PREFIX + freelancerId, payload);
-        
+
         // 프리랜서 리뷰가 변경되었으므로, 해당 프리랜서의 AI 분석 리포트 캐시 무효화
         if (redisTemplate != null) {
             try {
@@ -303,10 +306,11 @@ public class ReviewServiceImpl implements ReviewService {
         return value == null ? 0 : value;
     }
 
-    private double average(Integer... values) {
+    private double average(List<EmployerReview> reviews, java.util.function.Function<EmployerReview, Integer> extractor) {
         int sum = 0;
         int count = 0;
-        for (Integer value : values) {
+        for (EmployerReview review : reviews) {
+            Integer value = extractor.apply(review);
             if (value == null) {
                 continue;
             }
@@ -319,6 +323,10 @@ public class ReviewServiceImpl implements ReviewService {
         return (double) sum / count;
     }
 
+    private double round1(double value) {
+        return Math.round(value * 10.0) / 10.0;
+    }
+
     private void writeRedisValue(String key, Object value) {
         if (redisTemplate == null) {
             return;
@@ -327,6 +335,17 @@ public class ReviewServiceImpl implements ReviewService {
             redisTemplate.opsForValue().set(key, value);
         } catch (RuntimeException e) {
             log.warn("Failed to write mypage review payload. key={}", key, e);
+        }
+    }
+
+    private void deleteRedisValue(String key) {
+        if (redisTemplate == null) {
+            return;
+        }
+        try {
+            redisTemplate.delete(key);
+        } catch (RuntimeException e) {
+            log.warn("Failed to delete mypage review payload. key={}", key, e);
         }
     }
 

--- a/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/freelancer/response/FreelancerEvaluationSummaryDto.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/freelancer/response/FreelancerEvaluationSummaryDto.java
@@ -46,6 +46,31 @@ public record FreelancerEvaluationSummaryDto(
         return new FreelancerEvaluationSummaryDto(totalAverage, topPercentile, avgExpertise, avgCommunication, avgSchedule);
     }
 
+    public static FreelancerEvaluationSummaryDto fromAverageMap(Map<String, Object> averages, Integer topPercentile) {
+        if (averages == null || averages.isEmpty()) {
+            return empty(topPercentile);
+        }
+
+        double avgProgramming = safeNumber(averages.get("programming"));
+        double avgFramework = safeNumber(averages.get("framework"));
+        double avgDebugging = safeNumber(averages.get("debugging"));
+        double avgCommunication = safeNumber(averages.get("communication"));
+        double avgSchedule = safeNumber(averages.get("schedule"));
+
+        double expertiseRate = round1((avgProgramming + avgFramework + avgDebugging) / 3.0);
+        double communicationRate = round1(avgCommunication);
+        double scheduleRate = round1(avgSchedule);
+        double totalAverage = round1((expertiseRate + communicationRate + scheduleRate) / 3.0);
+
+        return new FreelancerEvaluationSummaryDto(
+                totalAverage,
+                topPercentile,
+                expertiseRate,
+                communicationRate,
+                scheduleRate
+        );
+    }
+
     /** Integer, Long, Double 등 모든 Number 하위 타입과 null을 안전하게 double로 변환합니다. */
     private static double safeNumber(Object value) {
         if (value instanceof Number n) {

--- a/freebridge/user/src/main/java/com/fallguys/mypage/service/freelancer/FreelancerReviewService.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/service/freelancer/FreelancerReviewService.java
@@ -33,7 +33,8 @@ public class FreelancerReviewService {
     /**
      * 내 평판/등급 요약 조회
      * Redis Key: freelancer:review:rates:{freelancerId}
-     * Expected value: List<Map<String, Double>> { expertiseRate, communicationRate, scheduleRate }
+     * Expected value:
+     * { programming, framework, debugging, communication, schedule, dispute }
      * topPercentile은 Freelancer 엔티티에서 조회합니다.
      */
     @Transactional(readOnly = true)
@@ -46,9 +47,17 @@ public class FreelancerReviewService {
             if (rawData == null) {
                 return FreelancerEvaluationSummaryDto.empty(topPercentile);
             }
-            @SuppressWarnings("unchecked")
-            List<Map<String, Object>> reviews = (List<Map<String, Object>>) rawData;
-            return FreelancerEvaluationSummaryDto.from(reviews, topPercentile);
+            if (rawData instanceof Map<?, ?> rawMap) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> averages = (Map<String, Object>) rawMap;
+                return FreelancerEvaluationSummaryDto.fromAverageMap(averages, topPercentile);
+            }
+            if (rawData instanceof List<?> rawList) {
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> reviews = (List<Map<String, Object>>) rawList;
+                return FreelancerEvaluationSummaryDto.from(reviews, topPercentile);
+            }
+            return FreelancerEvaluationSummaryDto.empty(topPercentile);
 
         } catch (Exception e) {
             log.error("Failed to parse freelancer review summary from Redis for userId: {}", userId, e);
@@ -67,6 +76,15 @@ public class FreelancerReviewService {
             Object ratesData = redisTemplate.opsForValue().get(ratesRedisKey);
             // 등록된 리뷰가 명시적으로 비어있을 경우에만 AI 서버 호출 생략
             if (ratesData instanceof List<?> list && list.isEmpty()) {
+                return new FreelancerAiReputationReportDto(
+                        "아직 충분한 리뷰가 등록되지 않았습니다.",
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList()
+                );
+            }
+            if (ratesData instanceof Map<?, ?> map && map.isEmpty()) {
                 return new FreelancerAiReputationReportDto(
                         "아직 충분한 리뷰가 등록되지 않았습니다.",
                         Collections.emptyList(),

--- a/freebridge/user/src/test/java/com/fallguys/mypage/service/freelancer/FreelancerReviewServiceTest.java
+++ b/freebridge/user/src/test/java/com/fallguys/mypage/service/freelancer/FreelancerReviewServiceTest.java
@@ -45,27 +45,31 @@ class FreelancerReviewServiceTest {
         String redisKey = "freelancer:review:rates:" + userId;
         Integer topPercentile = 15;
 
-        List<Map<String, Object>> mockReviews = List.of(
-                Map.of("expertiseRate", 4.0, "communicationRate", 5.0, "scheduleRate", 3.0),
-                Map.of("expertiseRate", 5, "communicationRate", 4, "scheduleRate", 4)  // 정수도 처리 가능 검증
+        Map<String, Object> mockAverages = Map.of(
+                "programming", 4.0,
+                "framework", 5.0,
+                "debugging", 3.0,
+                "communication", 5.0,
+                "schedule", 4.0,
+                "dispute", 2.0
         );
 
         Freelancer mockFreelancer = mock(Freelancer.class);
         given(mockFreelancer.getTopPercentile()).willReturn(topPercentile);
         given(freelancerRepository.findByUserId(userId)).willReturn(Optional.of(mockFreelancer));
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
-        given(valueOperations.get(redisKey)).willReturn(mockReviews);
+        given(valueOperations.get(redisKey)).willReturn(mockAverages);
 
         // when
         FreelancerEvaluationSummaryDto result = freelancerReviewService.getReviewSummary(userId);
 
         // then
         assertThat(result.topPercentile()).isEqualTo(15);
-        assertThat(result.expertiseRate()).isEqualTo(4.5);
-        assertThat(result.communicationRate()).isEqualTo(4.5);
-        assertThat(result.scheduleRate()).isEqualTo(3.5);
-        // averageRate = (4.5+4.5+3.5)/3 = 4.2
-        assertThat(result.averageRate()).isEqualTo(4.2);
+        assertThat(result.expertiseRate()).isEqualTo(4.0);
+        assertThat(result.communicationRate()).isEqualTo(5.0);
+        assertThat(result.scheduleRate()).isEqualTo(4.0);
+        // averageRate = (4.0+5.0+4.0)/3 = 4.3
+        assertThat(result.averageRate()).isEqualTo(4.3);
 
         verify(redisTemplate, times(1)).opsForValue();
         verify(valueOperations, times(1)).get(redisKey);
@@ -94,10 +98,37 @@ class FreelancerReviewServiceTest {
     }
 
     @Test
-    @DisplayName("[TDD] 3. 평판/등급 요약 조회: Freelancer가 없으면 topPercentile은 null, 나머지는 0인 DTO를 반환한다")
-    void getReviewSummary_FreelancerNotFound_ReturnsFallback() {
+    @DisplayName("[TDD] 3. 평판/등급 요약 조회: 레거시 List 포맷도 계속 읽을 수 있다")
+    void getReviewSummary_LegacyListFormat_Success() {
         // given
         Long userId = 3L;
+        String redisKey = "freelancer:review:rates:" + userId;
+
+        Freelancer mockFreelancer = mock(Freelancer.class);
+        given(mockFreelancer.getTopPercentile()).willReturn(20);
+        given(freelancerRepository.findByUserId(userId)).willReturn(Optional.of(mockFreelancer));
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(redisKey)).willReturn(List.of(
+                Map.of("expertiseRate", 4.0, "communicationRate", 5.0, "scheduleRate", 3.0),
+                Map.of("expertiseRate", 5, "communicationRate", 4, "scheduleRate", 4)
+        ));
+
+        // when
+        FreelancerEvaluationSummaryDto result = freelancerReviewService.getReviewSummary(userId);
+
+        // then
+        assertThat(result.topPercentile()).isEqualTo(20);
+        assertThat(result.expertiseRate()).isEqualTo(4.5);
+        assertThat(result.communicationRate()).isEqualTo(4.5);
+        assertThat(result.scheduleRate()).isEqualTo(3.5);
+        assertThat(result.averageRate()).isEqualTo(4.2);
+    }
+
+    @Test
+    @DisplayName("[TDD] 4. 평판/등급 요약 조회: Freelancer가 없으면 topPercentile은 null, 나머지는 0인 DTO를 반환한다")
+    void getReviewSummary_FreelancerNotFound_ReturnsFallback() {
+        // given
+        Long userId = 4L;
         String redisKey = "freelancer:review:rates:" + userId;
 
         given(freelancerRepository.findByUserId(userId)).willReturn(Optional.empty());


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #

## 📝 작업 내용
프리랜서 리뷰 평점 Redis 저장 형식을 기존 리뷰별 배열 구조에서 항목별 평균을 담은 단일 객체 형태로 변경하고, 이를 읽는 마이페이지 요약 로직이 새 포맷과 기존 포맷을 모두 처리할 수 있도록 보완했습니다.

## ✅ Changes
- `employer_freelancer_reviews` 기준으로 프리랜서 리뷰 점수를 항목별 평균 집계 후 Redis에 단일 객체로 저장하도록 변경
- Redis 저장 키 `freelancer:review:rates:{freelancerId}`의 payload를 `programming/framework/debugging/communication/schedule/dispute` 구조로 정리
- 프리랜서 마이페이지 리뷰 요약 서비스가 새 평균 객체 포맷을 읽도록 수정
- 기존 배열 포맷(`expertiseRate/communicationRate/scheduleRate`)도 임시 호환 처리 추가
- 프리랜서 리뷰 요약 테스트를 새 Redis 포맷 기준 및 레거시 호환 케이스로 갱신

## 📸 스크린샷 (선택)
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
- Redis에는 이제 아래 형태로 저장됩니다.
```json
{
  "programming": 1.0,
  "framework": 1.0,
  "debugging": 1.0,
  "communication": 1.0,
  "schedule": 1.0,
  "dispute": 1.0
}
```
- 기존 Redis에 남아 있는 레거시 배열 포맷 데이터는 읽기 호환을 유지했지만, 새 리뷰 생성/수정/삭제가 발생하면 새 포맷으로 갱신됩니다.
- 검증은 `./gradlew :review:compileJava :user:compileJava`로 확인했습니다.
- `:user:test --tests com.fallguys.mypage.service.freelancer.FreelancerReviewServiceTest`는 이번 변경과 무관한 기존 `EmployerProfileServiceTest` 컴파일 에러 때문에 전체 실행이 막힙니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 프리랜서 평가 요약 데이터의 새로운 형식 지원 추가

* **Bug Fixes**
  * 평가 데이터 처리 시 레거시 형식 호환성 및 오류 처리 개선
  * 데이터 부재 시 안전한 초기화 및 폴백 동작 추가

* **Tests**
  * 새로운 데이터 형식 검증 테스트 케이스 추가
  * 레거시 형식 호환성 테스트 추가

* **Refactor**
  * 평가 집계 로직 최적화 및 Redis 캐시 처리 방식 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->