### PR TITLE
HFP-118[feat] chatting 백엔드에 채팅방 contractId를 저장하는 api추가

### DIFF
--- a/freebridge/chatting/src/main/java/com/fallguys/chatting/api/web/ChatRoomController.java
+++ b/freebridge/chatting/src/main/java/com/fallguys/chatting/api/web/ChatRoomController.java
@@ -1,6 +1,7 @@
 package com.fallguys.chatting.api.web;
 
 import com.fallguys.chatting.api.web.dto.request.ChatRoomCreateRequest;
+import com.fallguys.chatting.api.web.dto.request.ChatRoomContractUpdateRequest;
 import com.fallguys.chatting.api.web.dto.response.ChatRoomResponse;
 import com.fallguys.chatting.api.web.dto.response.CursorPageResponse;
 import com.fallguys.chatting.api.web.dto.response.ChatMessageResponse;
@@ -64,6 +65,16 @@ public class ChatRoomController {
             @PathVariable String roomId) {
         String userId = extractUserId(authHeader);
         ChatRoomResponse response = chatRoomService.leaveChatRoom(roomId, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{roomId}/contract")
+    public ResponseEntity<ChatRoomResponse> updateRoomContract(
+            @RequestHeader("Authorization") String authHeader,
+            @PathVariable String roomId,
+            @RequestBody ChatRoomContractUpdateRequest request) {
+        String userId = extractUserId(authHeader);
+        ChatRoomResponse response = chatRoomService.updateRoomContract(roomId, userId, request.getContractId());
         return ResponseEntity.ok(response);
     }
 

--- a/freebridge/chatting/src/main/java/com/fallguys/chatting/api/web/GlobalChatExceptionHandler.java
+++ b/freebridge/chatting/src/main/java/com/fallguys/chatting/api/web/GlobalChatExceptionHandler.java
@@ -7,10 +7,17 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 @Slf4j
 @RestControllerAdvice(basePackages = "com.fallguys.chatting.api.web")
 public class GlobalChatExceptionHandler {
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<Map<String, String>> handleNoSuchElementException(NoSuchElementException e) {
+        log.warn("Chatting module not found: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", e.getMessage()));
+    }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException e) {

--- a/freebridge/chatting/src/main/java/com/fallguys/chatting/api/web/dto/request/ChatRoomContractUpdateRequest.java
+++ b/freebridge/chatting/src/main/java/com/fallguys/chatting/api/web/dto/request/ChatRoomContractUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.fallguys.chatting.api.web.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChatRoomContractUpdateRequest {
+
+    private Long contractId;
+}

--- a/freebridge/chatting/src/main/java/com/fallguys/chatting/domain/ChatRoom.java
+++ b/freebridge/chatting/src/main/java/com/fallguys/chatting/domain/ChatRoom.java
@@ -98,6 +98,14 @@ public class ChatRoom {
         }
     }
 
+    public boolean isParticipant(String participantId) {
+        return participantId != null && participants.contains(participantId);
+    }
+
+    public boolean isEmployerParticipant(String participantId) {
+        return isParticipant(participantId) && participantId.toLowerCase().startsWith("e");
+    }
+
     // 5. 모두가 방을 나갔는지 확인
     public boolean hasEveryoneLeft() {
         return leftBy.containsAll(participants);
@@ -105,6 +113,12 @@ public class ChatRoom {
 
     // 6. 새로운 계약이 성사되었을 때 연결
     public void updateContractId(Long contractId) {
+        if (contractId == null) {
+            throw new IllegalArgumentException("연결할 계약 ID가 필요합니다.");
+        }
+        if (this.contractId != null && !this.contractId.equals(contractId)) {
+            throw new IllegalArgumentException("이미 계약이 연결된 채팅방입니다. 기존 계약을 덮어쓸 수 없습니다.");
+        }
         this.contractId = contractId;
     }
 }

--- a/freebridge/chatting/src/main/java/com/fallguys/chatting/service/ChatRoomService.java
+++ b/freebridge/chatting/src/main/java/com/fallguys/chatting/service/ChatRoomService.java
@@ -1,14 +1,16 @@
 package com.fallguys.chatting.service;
 
-import com.fallguys.chatting.domain.ChatRoom;
 import com.fallguys.chatting.api.web.dto.response.ChatRoomResponse;
+import com.fallguys.chatting.domain.ChatRoom;
 import com.fallguys.chatting.repository.ChatRoomRepository;
+import com.fallguys.common.api.contract.ContractQuery;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -20,6 +22,7 @@ public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatPresenceService chatPresenceService;
     private final ChatMessageService chatMessageService;
+    private final ContractQuery contractQuery;
 
     /**
      * 1:1 채팅방 생성 (이미 방이 존재할 경우 기존 방을 반환하는 로직은 추후 추가)
@@ -94,6 +97,12 @@ public class ChatRoomService {
                     room.getContractId(),
                     contractId);
             throw new IllegalArgumentException("이미 계약이 연결된 채팅방입니다. 기존 계약을 덮어쓸 수 없습니다.");
+        }
+
+        if (!contractQuery.existsContract(contractId)) {
+            log.warn("존재하지 않는 계약 연결 시도 - roomId: {}, participantId: {}, contractId: {}", roomId, participantId,
+                    contractId);
+            throw new NoSuchElementException("계약을 찾을 수 없습니다.");
         }
 
         room.updateContractId(contractId);

--- a/freebridge/chatting/src/main/java/com/fallguys/chatting/service/ChatRoomService.java
+++ b/freebridge/chatting/src/main/java/com/fallguys/chatting/service/ChatRoomService.java
@@ -74,9 +74,26 @@ public class ChatRoomService {
         ChatRoom room = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다: " + roomId));
 
-        if (!room.getParticipants().contains(participantId)) {
+        if (!room.isParticipant(participantId)) {
             log.warn("권한 없는 사용자의 채팅방 계약 연결 시도 - roomId: {}, participantId: {}", roomId, participantId);
             throw new IllegalArgumentException("채팅방에 참여하고 있지 않습니다.");
+        }
+        if (!room.isEmployerParticipant(participantId)) {
+            log.warn("기업 회원이 아닌 사용자의 채팅방 계약 연결 시도 - roomId: {}, participantId: {}", roomId, participantId);
+            throw new IllegalArgumentException("기업 회원만 채팅방에 계약을 연결할 수 있습니다.");
+        }
+        if (contractId == null) {
+            log.warn("계약 ID 없이 채팅방 계약 연결 시도 - roomId: {}, participantId: {}", roomId, participantId);
+            throw new IllegalArgumentException("연결할 계약 ID가 필요합니다.");
+        }
+        if (room.getContractId() != null && !room.getContractId().equals(contractId)) {
+            log.warn(
+                    "기존 계약이 연결된 채팅방 덮어쓰기 시도 - roomId: {}, participantId: {}, currentContractId: {}, requestedContractId: {}",
+                    roomId,
+                    participantId,
+                    room.getContractId(),
+                    contractId);
+            throw new IllegalArgumentException("이미 계약이 연결된 채팅방입니다. 기존 계약을 덮어쓸 수 없습니다.");
         }
 
         room.updateContractId(contractId);

--- a/freebridge/chatting/src/main/java/com/fallguys/chatting/service/ChatRoomService.java
+++ b/freebridge/chatting/src/main/java/com/fallguys/chatting/service/ChatRoomService.java
@@ -70,6 +70,20 @@ public class ChatRoomService {
         return ChatRoomResponse.from(savedRoom, buildParticipantPresence(savedRoom));
     }
 
+    public ChatRoomResponse updateRoomContract(String roomId, String participantId, Long contractId) {
+        ChatRoom room = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다: " + roomId));
+
+        if (!room.getParticipants().contains(participantId)) {
+            log.warn("권한 없는 사용자의 채팅방 계약 연결 시도 - roomId: {}, participantId: {}", roomId, participantId);
+            throw new IllegalArgumentException("채팅방에 참여하고 있지 않습니다.");
+        }
+
+        room.updateContractId(contractId);
+        ChatRoom savedRoom = chatRoomRepository.save(room);
+        return ChatRoomResponse.from(savedRoom, buildParticipantPresence(savedRoom));
+    }
+
     private Map<String, Boolean> buildParticipantPresence(ChatRoom room) {
         return room.getParticipants().stream()
                 .collect(Collectors.toMap(Function.identity(), chatPresenceService::isUserOnline));

--- a/freebridge/common/src/main/java/com/fallguys/common/api/contract/ContractQuery.java
+++ b/freebridge/common/src/main/java/com/fallguys/common/api/contract/ContractQuery.java
@@ -2,5 +2,7 @@ package com.fallguys.common.api.contract;
 
 public interface ContractQuery {
 
+    boolean existsContract(Long contractId);
+
     ContractInfo getContractInfo(Long contractId);
 }

--- a/freebridge/contract/src/main/java/com/fallguys/contract/service/ContractQueryService.java
+++ b/freebridge/contract/src/main/java/com/fallguys/contract/service/ContractQueryService.java
@@ -17,6 +17,11 @@ public class ContractQueryService implements ContractQuery {
     private final ContractRepository contractRepository;
 
     @Override
+    public boolean existsContract(Long contractId) {
+        return contractRepository.existsById(contractId);
+    }
+
+    @Override
     public ContractInfo getContractInfo(Long contractId) {
         var c = contractRepository.findById(contractId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CONTRACT_NOT_FOUND));


### PR DESCRIPTION
## 🔗 Related Issue
> 이슈 번호를 작성해주세요. (예: Closes #123)
- Closes #

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

## ✅ Changes
> 주요 변경 사항을 bullet point로 정리합니다.

## 📸 스크린샷 (선택)
> UI 변경 사항이나 테스트 결과 화면이 있다면 첨부해주세요.
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
> 리뷰 시 유의할 점, 후속 PR 예정 사항, 배포 영향 등을 적습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 인증된 사용자가 채팅방의 계약 정보를 업데이트할 수 있는 기능이 추가되었습니다.
* **버그 수정 / 개선**
  * 요청 입력 검증과 권한 체크가 강화되어 유효하지 않은 요청이나 권한 없는 사용자의 변경 시 명확한 오류 응답이 반환됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->