### PR TITLE
Hfp 96  fix: 프리랜서 리뷰 요약 Redis를 cache-aside로 전환하고 마이페이지 조회 시 캐시 생성을 보장

### DIFF
--- a/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
+++ b/freebridge/matchs/src/main/java/com/fallguys/matchs/service/MatchsServiceImpl.java
@@ -26,7 +26,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -35,7 +34,6 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -55,9 +53,8 @@ public class MatchsServiceImpl implements MatchsService {
     private static final String EMPLOYER_PROJECT_LIST_KEY_PREFIX = "employer:project:list:";
     private static final String EMPLOYER_PROJECT_APPLICANTS_KEY_PREFIX = "employer:project:applicants:";
     private static final String FREELANCER_PROJECT_STATS_KEY_PREFIX = "freelancer:project:stats:";
-    private static final String FREELANCER_PROJECT_APPLIED_KEY_PREFIX = "freelancer:project:applied:";
+    private static final String FREELANCER_PROJECT_LIST_KEY_PREFIX = "freelancer:project:list:";
     private static final DateTimeFormatter ISO_SECONDS_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
-    private static final int FREELANCER_APPLIED_CACHE_LIMIT = 100;
     private static final int APPLICANT_COUNT_QUERY_CHUNK_SIZE = 500;
 
     private final ApplicationRepo applicationRepo;
@@ -88,7 +85,7 @@ public class MatchsServiceImpl implements MatchsService {
             refreshEmployerProjectList(jobPosting.getEmployerId());
             refreshEmployerProjectApplicants(applicationId);
             refreshFreelancerProjectStats(freelancerId);
-            refreshFreelancerAppliedProjects(freelancerId);
+            refreshFreelancerProjectList(freelancerId);
         });
         return applicationId;
     }
@@ -117,7 +114,7 @@ public class MatchsServiceImpl implements MatchsService {
             refreshEmployerProjectStats(employerId);
             refreshEmployerProjectList(employerId);
             refreshFreelancerProjectStats(request.freelancerId());
-            refreshFreelancerAppliedProjects(request.freelancerId());
+            refreshFreelancerProjectList(request.freelancerId());
         });
         return proposalId;
     }
@@ -138,7 +135,7 @@ public class MatchsServiceImpl implements MatchsService {
             refreshEmployerProjectList(application.getEmployerId());
             refreshEmployerProjectApplicants(application.getId());
             refreshFreelancerProjectStats(application.getFreelancerId());
-            refreshFreelancerAppliedProjects(application.getFreelancerId());
+            refreshFreelancerProjectList(application.getFreelancerId());
         });
         return projectId;
     }
@@ -158,7 +155,7 @@ public class MatchsServiceImpl implements MatchsService {
             refreshEmployerProjectStats(proposal.getEmployerId());
             refreshEmployerProjectList(proposal.getEmployerId());
             refreshFreelancerProjectStats(freelancerId);
-            refreshFreelancerAppliedProjects(freelancerId);
+            refreshFreelancerProjectList(freelancerId);
         });
         return projectId;
     }
@@ -179,7 +176,7 @@ public class MatchsServiceImpl implements MatchsService {
             refreshEmployerProjectList(application.getEmployerId());
             refreshEmployerProjectApplicants(application.getId());
             refreshFreelancerProjectStats(application.getFreelancerId());
-            refreshFreelancerAppliedProjects(application.getFreelancerId());
+            refreshFreelancerProjectList(application.getFreelancerId());
         });
         return application.getId();
     }
@@ -199,7 +196,7 @@ public class MatchsServiceImpl implements MatchsService {
             refreshEmployerProjectStats(proposal.getEmployerId());
             refreshEmployerProjectList(proposal.getEmployerId());
             refreshFreelancerProjectStats(freelancerId);
-            refreshFreelancerAppliedProjects(freelancerId);
+            refreshFreelancerProjectList(freelancerId);
         });
         return proposal.getId();
     }
@@ -583,60 +580,45 @@ public class MatchsServiceImpl implements MatchsService {
         writeRedisValue(FREELANCER_PROJECT_STATS_KEY_PREFIX + freelancerId, payload);
     }
 
-    private void refreshFreelancerAppliedProjects(Long freelancerId) {
-        Pageable limitPageable = PageRequest.of(0, FREELANCER_APPLIED_CACHE_LIMIT);
-        List<Application> applications = orEmpty(
-                applicationRepo.findAllByFreelancerIdOrderByCreatedAtDesc(freelancerId, limitPageable).getContent()
-        );
-        List<Proposal> proposals = orEmpty(
-                proposalRepo.findAllByFreelancerIdOrderByCreatedAtDesc(freelancerId, limitPageable).getContent()
-        );
+    private void refreshFreelancerProjectList(Long freelancerId) {
+        List<Project> projects = orEmpty(projectPostingRepo.findAllByFreelancerIdOrderByCreatedAtDesc(freelancerId));
 
         Set<Long> postingIds = new LinkedHashSet<>();
-        applications.stream().map(Application::getJobPostingId).forEach(postingIds::add);
-        proposals.stream().map(Proposal::getJobPostingId).forEach(postingIds::add);
+        projects.stream()
+                .map(Project::getJobPosting)
+                .filter(Objects::nonNull)
+                .map(JobPosting::getId)
+                .filter(Objects::nonNull)
+                .forEach(postingIds::add);
 
         Map<Long, JobPosting> postingsById = new HashMap<>();
         if (!postingIds.isEmpty()) {
             jobPostingRepo.findAllById(postingIds).forEach(posting -> postingsById.put(posting.getId(), posting));
         }
 
-        List<Map<String, Object>> payload = new ArrayList<>();
-        for (Application application : applications) {
-            JobPosting posting = postingsById.get(application.getJobPostingId());
-            payload.add(toFreelancerAppliedItem(
-                    application.getJobPostingId(),
-                    posting,
-                    toFreelancerApplyStatus(application.getStatus()),
-                    application.getCreatedAt()
-            ));
-        }
-        for (Proposal proposal : proposals) {
-            JobPosting posting = postingsById.get(proposal.getJobPostingId());
-            payload.add(toFreelancerAppliedItem(
-                    proposal.getJobPostingId(),
-                    posting,
-                    toFreelancerApplyStatus(proposal.getStatus()),
-                    proposal.getCreatedAt()
-            ));
+        List<Map<String, Object>> payload = new ArrayList<>(projects.size());
+        for (Project project : projects) {
+            JobPosting posting = project.getJobPosting();
+            if (posting != null && posting.getId() != null) {
+                posting = postingsById.getOrDefault(posting.getId(), posting);
+            }
+            payload.add(toFreelancerProjectItem(project, posting));
         }
 
-        payload.sort(Comparator.comparingLong(item -> (Long) item.get("appliedAt")));
-        java.util.Collections.reverse(payload);
-        if (payload.size() > FREELANCER_APPLIED_CACHE_LIMIT) {
-            payload = new ArrayList<>(payload.subList(0, FREELANCER_APPLIED_CACHE_LIMIT));
-        }
-
-        writeRedisValue(FREELANCER_PROJECT_APPLIED_KEY_PREFIX + freelancerId, payload);
+        writeRedisValue(FREELANCER_PROJECT_LIST_KEY_PREFIX + freelancerId, payload);
     }
 
-    private Map<String, Object> toFreelancerAppliedItem(Long projectId, JobPosting posting, String applyStatus, LocalDateTime appliedAt) {
+    private Map<String, Object> toFreelancerProjectItem(Project project, JobPosting posting) {
         Map<String, Object> item = new HashMap<>();
-        item.put("projectId", projectId);
-        item.put("title", posting != null ? posting.getTitle() : null);
+        item.put("projectId", project.getId());
+        item.put("title", posting != null ? posting.getTitle() : project.getProjectName());
         item.put("employerName", posting != null ? posting.getEmployerName() : null);
-        item.put("applyStatus", applyStatus);
-        item.put("appliedAt", toEpochMillis(appliedAt));
+        item.put("projectStatus", toFreelancerProjectStatus(project.getStatus()));
+        item.put("description", posting != null ? posting.getDescription() : null);
+        item.put("budget", posting != null ? posting.getBudget() : null);
+        item.put("techStack", posting != null ? List.copyOf(posting.getTechStack()) : List.of());
+        item.put("startDate", project.getStartDate() != null ? project.getStartDate().toString() : null);
+        item.put("endDate", project.getEndDate() != null ? project.getEndDate().toString() : null);
         return item;
     }
 
@@ -663,14 +645,14 @@ public class MatchsServiceImpl implements MatchsService {
         };
     }
 
-    private String toFreelancerApplyStatus(MatchsStatus status) {
+    private String toFreelancerProjectStatus(ProjectStatus status) {
         if (status == null) {
-            return "심사중";
+            return "IN_PROGRESS";
         }
         return switch (status) {
-            case PENDING -> "심사중";
-            case ACCEPTED -> "합격";
-            case REJECTED -> "거절";
+            case IN_PROGRESS -> "IN_PROGRESS";
+            case COMPLETED -> "COMPLETED";
+            case CANCELLED -> "CANCELED";
         };
     }
 
@@ -679,13 +661,6 @@ public class MatchsServiceImpl implements MatchsService {
             return null;
         }
         return dateTime.format(ISO_SECONDS_FORMATTER);
-    }
-
-    private long toEpochMillis(LocalDateTime dateTime) {
-        if (dateTime == null) {
-            return 0L;
-        }
-        return dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
     }
 
     private Long parseLongSafely(Object value) {

--- a/freebridge/review/src/main/java/com/fallguys/review/service/ReviewServiceImpl.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/service/ReviewServiceImpl.java
@@ -24,11 +24,8 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 @Slf4j
 @Service
@@ -95,7 +92,7 @@ public class ReviewServiceImpl implements ReviewService {
             EmployerReview savedReview = employerReviewRepository.save(review);
             Long reviewId = savedReview.getId();
 
-            runAfterCommitSafely(() -> refreshFreelancerReviewRates(request.freelancerId()));
+            runAfterCommitSafely(() -> invalidateFreelancerReviewCaches(request.freelancerId()));
 
             projectExternalApi.completeProjectWithReview(
                     new ProjectExternalApi.ProjectCompletionData(
@@ -139,7 +136,7 @@ public class ReviewServiceImpl implements ReviewService {
                 request.dispute(),
                 request.description()
         );
-        runAfterCommitSafely(() -> refreshFreelancerReviewRates(review.getFreelancerId()));
+        runAfterCommitSafely(() -> invalidateFreelancerReviewCaches(review.getFreelancerId()));
     }
 
     @Override
@@ -152,7 +149,7 @@ public class ReviewServiceImpl implements ReviewService {
                 )
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE));
         review.softDelete();
-        runAfterCommitSafely(() -> refreshFreelancerReviewRates(review.getFreelancerId()));
+        runAfterCommitSafely(() -> invalidateFreelancerReviewCaches(review.getFreelancerId()));
     }
 
     @Override
@@ -199,7 +196,7 @@ public class ReviewServiceImpl implements ReviewService {
 
         try {
             Long reviewId = freelancerReviewRepository.save(review).getId();
-            runAfterCommitSafely(() -> refreshEmployerReviewRates(request.employerId()));
+            runAfterCommitSafely(() -> invalidateEmployerReviewCache(request.employerId()));
             return reviewId;
         } catch (DataIntegrityViolationException e) {
             if (!isDuplicateKeyViolation(e)) {
@@ -225,7 +222,7 @@ public class ReviewServiceImpl implements ReviewService {
                 request.schedule(),
                 request.description()
         );
-        runAfterCommitSafely(() -> refreshEmployerReviewRates(review.getEmployerId()));
+        runAfterCommitSafely(() -> invalidateEmployerReviewCache(review.getEmployerId()));
     }
 
     @Override
@@ -238,7 +235,7 @@ public class ReviewServiceImpl implements ReviewService {
                 )
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE));
         review.softDelete();
-        runAfterCommitSafely(() -> refreshEmployerReviewRates(review.getEmployerId()));
+        runAfterCommitSafely(() -> invalidateEmployerReviewCache(review.getEmployerId()));
     }
 
     private void runAfterCommit(Runnable task) {
@@ -264,78 +261,13 @@ public class ReviewServiceImpl implements ReviewService {
         });
     }
 
-    private void refreshEmployerReviewRates(Long employerId) {
-        List<FreelancerReview> reviews = orEmpty(freelancerReviewRepository.findAllByEmployerIdAndStatus(employerId, ReviewStatus.ACTIVE));
-        List<Map<String, Object>> payload = new ArrayList<>(reviews.size());
-        for (FreelancerReview review : reviews) {
-            Map<String, Object> item = new HashMap<>();
-            item.put("atmosphereRate", toNumberOrZero(review.getAtmosphere()));
-            item.put("requirementsDetailRate", toNumberOrZero(review.getRequirementDetail()));
-            item.put("scheduleAdherenceRate", toNumberOrZero(review.getSchedule()));
-            payload.add(item);
-        }
-        writeRedisValue(EMPLOYER_REVIEW_RATES_KEY_PREFIX + employerId, payload);
+    private void invalidateEmployerReviewCache(Long employerId) {
+        deleteRedisValue(EMPLOYER_REVIEW_RATES_KEY_PREFIX + employerId);
     }
 
-    private void refreshFreelancerReviewRates(Long freelancerId) {
-        List<EmployerReview> reviews = orEmpty(employerReviewRepository.findAllByFreelancerIdAndStatus(freelancerId, ReviewStatus.ACTIVE));
-        if (reviews.isEmpty()) {
-            deleteRedisValue(FREELANCER_REVIEW_RATES_KEY_PREFIX + freelancerId);
-        } else {
-            Map<String, Object> payload = new HashMap<>();
-            payload.put("programming", round1(average(reviews, EmployerReview::getLanguage)));
-            payload.put("framework", round1(average(reviews, EmployerReview::getFramework)));
-            payload.put("debugging", round1(average(reviews, EmployerReview::getDebugging)));
-            payload.put("communication", round1(average(reviews, EmployerReview::getCommunication)));
-            payload.put("schedule", round1(average(reviews, EmployerReview::getSchedule)));
-            payload.put("dispute", round1(average(reviews, EmployerReview::getDispute)));
-            writeRedisValue(FREELANCER_REVIEW_RATES_KEY_PREFIX + freelancerId, payload);
-        }
-
-        // 프리랜서 리뷰가 변경되었으므로, 해당 프리랜서의 AI 분석 리포트 캐시 무효화
-        if (redisTemplate != null) {
-            try {
-                redisTemplate.delete("freelancer:review:ai_report:" + freelancerId);
-            } catch (Exception e) {
-                log.warn("Failed to invalidate AI report cache for freelancerId: {}", freelancerId, e);
-            }
-        }
-    }
-
-    private Number toNumberOrZero(Integer value) {
-        return value == null ? 0 : value;
-    }
-
-    private double average(List<EmployerReview> reviews, java.util.function.Function<EmployerReview, Integer> extractor) {
-        int sum = 0;
-        int count = 0;
-        for (EmployerReview review : reviews) {
-            Integer value = extractor.apply(review);
-            if (value == null) {
-                continue;
-            }
-            sum += value;
-            count++;
-        }
-        if (count == 0) {
-            return 0.0;
-        }
-        return (double) sum / count;
-    }
-
-    private double round1(double value) {
-        return Math.round(value * 10.0) / 10.0;
-    }
-
-    private void writeRedisValue(String key, Object value) {
-        if (redisTemplate == null) {
-            return;
-        }
-        try {
-            redisTemplate.opsForValue().set(key, value);
-        } catch (RuntimeException e) {
-            log.warn("Failed to write mypage review payload. key={}", key, e);
-        }
+    private void invalidateFreelancerReviewCaches(Long freelancerId) {
+        deleteRedisValue(FREELANCER_REVIEW_RATES_KEY_PREFIX + freelancerId);
+        deleteRedisValue("freelancer:review:ai_report:" + freelancerId);
     }
 
     private void deleteRedisValue(String key) {
@@ -348,11 +280,6 @@ public class ReviewServiceImpl implements ReviewService {
             log.warn("Failed to delete mypage review payload. key={}", key, e);
         }
     }
-
-    private <T> List<T> orEmpty(List<T> list) {
-        return list == null ? List.of() : list;
-    }
-
     private boolean isDuplicateKeyViolation(Throwable throwable) {
         Throwable current = throwable;
         while (current != null) {

--- a/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/freelancer/response/FreelancerAppliedProjectListDto.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/freelancer/response/FreelancerAppliedProjectListDto.java
@@ -1,9 +1,0 @@
-package com.fallguys.mypage.api.web.dto.freelancer.response;
-
-public record FreelancerAppliedProjectListDto(
-        Long projectId,
-        String title,
-        String employerName,
-        String applyStatus, // 심사중, 합격, 거절
-        Long appliedAt // 지원일자 Timestamp 혹은 LocalDateTime
-) {}

--- a/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/freelancer/response/FreelancerProjectListDto.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/freelancer/response/FreelancerProjectListDto.java
@@ -1,0 +1,15 @@
+package com.fallguys.mypage.api.web.dto.freelancer.response;
+
+import java.util.List;
+
+public record FreelancerProjectListDto(
+        Long projectId,
+        String title,
+        String employerName,
+        String projectStatus,
+        String description,
+        Long budget,
+        List<String> techStack,
+        String startDate,
+        String endDate
+) {}

--- a/freebridge/user/src/main/java/com/fallguys/mypage/api/web/freelancer/FreelancerProjectController.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/api/web/freelancer/FreelancerProjectController.java
@@ -2,7 +2,7 @@ package com.fallguys.mypage.api.web.freelancer;
 
 import com.fallguys.common.response.ApiResponse;
 import com.fallguys.common.security.CustomUserDetails;
-import com.fallguys.mypage.api.web.dto.freelancer.response.FreelancerAppliedProjectListDto;
+import com.fallguys.mypage.api.web.dto.freelancer.response.FreelancerProjectListDto;
 import com.fallguys.mypage.api.web.dto.freelancer.response.FreelancerProjectStatusStatsDto;
 import com.fallguys.mypage.service.freelancer.FreelancerProjectService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,10 +27,10 @@ public class FreelancerProjectController {
         return ApiResponse.ok(freelancerProjectService.getProjectStats(userDetails.getId()));
     }
 
-    @Operation(summary = "내 지원 및 진행 프로젝트 목록", description = "상태값을 받아(status파라미터 등) 해당 프로젝트 목록을 조회합니다.")
+    @Operation(summary = "내 프로젝트 목록", description = "상태값을 받아(status 파라미터) 해당 프로젝트 목록을 조회합니다.")
     @GetMapping
-    public ApiResponse<List<FreelancerAppliedProjectListDto>> getMyProjects(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                            @RequestParam(required = false) String status) {
+    public ApiResponse<List<FreelancerProjectListDto>> getMyProjects(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                     @RequestParam(required = false) String status) {
         return ApiResponse.ok(freelancerProjectService.getMyProjects(userDetails.getId(), status));
     }
 }

--- a/freebridge/user/src/main/java/com/fallguys/mypage/service/employer/EmployerReviewService.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/service/employer/EmployerReviewService.java
@@ -66,6 +66,7 @@ public class EmployerReviewService {
         @SuppressWarnings("unchecked")
         List<Object[]> rows = query.getResultList();
         if (rows == null || rows.isEmpty()) {
+            cacheEmployerReviewSummary(redisKey, List.of());
             return EmployerReviewSummaryResponseDto.empty();
         }
 
@@ -78,13 +79,16 @@ public class EmployerReviewService {
             ));
         }
 
+        cacheEmployerReviewSummary(redisKey, payload);
+        return EmployerReviewSummaryResponseDto.from(payload);
+    }
+
+    private void cacheEmployerReviewSummary(String redisKey, List<Map<String, Object>> payload) {
         try {
             redisTemplate.opsForValue().set(redisKey, payload);
         } catch (Exception e) {
-            log.warn("고용주 리뷰 요약을 Redis에 저장하지 못했습니다. employerId={}", employerId, e);
+            log.warn("고용주 리뷰 요약을 Redis에 저장하지 못했습니다. key={}", redisKey, e);
         }
-
-        return EmployerReviewSummaryResponseDto.from(payload);
     }
 
     private Long resolveEmployerId(Long userId) {

--- a/freebridge/user/src/main/java/com/fallguys/mypage/service/employer/EmployerReviewService.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/service/employer/EmployerReviewService.java
@@ -3,11 +3,16 @@ package com.fallguys.mypage.service.employer;
 import com.fallguys.common.ai.port.ReviewEngine;
 import com.fallguys.mypage.api.web.dto.employer.response.EmployerReputationAiResponseDto;
 import com.fallguys.mypage.api.web.dto.employer.response.EmployerReviewSummaryResponseDto;
+import com.fallguys.mypage.entity.employer.Employer;
+import com.fallguys.mypage.repository.employer.EmployerRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -18,16 +23,23 @@ import java.util.Map;
 public class EmployerReviewService {
 
     private final RedisTemplate<String, Object> redisTemplate;
+    private final EmployerRepository employerRepository;
+    private final EntityManager entityManager;
     private final ReviewEngine reviewEngine;
 
     public EmployerReviewSummaryResponseDto getReputationSummary(Long userId) {
-        String redisKey = "employer:review:rates:" + userId;
+        Long employerId = resolveEmployerId(userId);
+        if (employerId == null) {
+            return EmployerReviewSummaryResponseDto.empty();
+        }
+
+        String redisKey = "employer:review:rates:" + employerId;
         
         try {
             Object rawData = redisTemplate.opsForValue().get(redisKey);
             
             if (rawData == null) {
-                return EmployerReviewSummaryResponseDto.empty();
+                return buildAndCacheSummary(employerId, redisKey);
             }
 
             @SuppressWarnings("unchecked")
@@ -39,6 +51,58 @@ public class EmployerReviewService {
             log.error("Failed to parse employer review summary from Redis for employerId: {}", userId, e);
             return EmployerReviewSummaryResponseDto.empty();
         }
+    }
+
+    private EmployerReviewSummaryResponseDto buildAndCacheSummary(Long employerId, String redisKey) {
+        Query query = entityManager.createNativeQuery("""
+                SELECT atmosphere, requirement_detail, schedule
+                FROM freelancer_employer_reviews
+                WHERE employer_id = :employerId
+                  AND status = 'ACTIVE'
+                  AND deleted = false
+                """);
+        query.setParameter("employerId", employerId);
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = query.getResultList();
+        if (rows == null || rows.isEmpty()) {
+            return EmployerReviewSummaryResponseDto.empty();
+        }
+
+        List<Map<String, Object>> payload = new ArrayList<>(rows.size());
+        for (Object[] row : rows) {
+            payload.add(Map.of(
+                    "atmosphereRate", numberValue(row[0]),
+                    "requirementsDetailRate", numberValue(row[1]),
+                    "scheduleAdherenceRate", numberValue(row[2])
+            ));
+        }
+
+        try {
+            redisTemplate.opsForValue().set(redisKey, payload);
+        } catch (Exception e) {
+            log.warn("고용주 리뷰 요약을 Redis에 저장하지 못했습니다. employerId={}", employerId, e);
+        }
+
+        return EmployerReviewSummaryResponseDto.from(payload);
+    }
+
+    private Long resolveEmployerId(Long userId) {
+        try {
+            return employerRepository.findByUserId(userId)
+                    .map(Employer::getEmployerId)
+                    .orElse(null);
+        } catch (Exception e) {
+            log.warn("userId로 employerId를 찾지 못했습니다. userId={}", userId, e);
+            return null;
+        }
+    }
+
+    private double numberValue(Object value) {
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        return 0.0;
     }
 
     public EmployerReputationAiResponseDto getAiReputation(Long userId) {

--- a/freebridge/user/src/main/java/com/fallguys/mypage/service/freelancer/FreelancerProjectService.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/service/freelancer/FreelancerProjectService.java
@@ -1,6 +1,6 @@
 package com.fallguys.mypage.service.freelancer;
 
-import com.fallguys.mypage.api.web.dto.freelancer.response.FreelancerAppliedProjectListDto;
+import com.fallguys.mypage.api.web.dto.freelancer.response.FreelancerProjectListDto;
 import com.fallguys.mypage.api.web.dto.freelancer.response.FreelancerProjectStatusStatsDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,12 +41,14 @@ public class FreelancerProjectService {
     }
 
     /**
-     * 프리랜서의 지원/진행 프로젝트 목록 조회 (상태 필터링 지원)
-     * Redis Key: freelancer:project:applied:{freelancerId}
-     * Expected value: List<Map<String, Object>> { projectId, title, employerName, applyStatus, appliedAt }
+     * 프리랜서의 프로젝트 목록 조회 (상태 필터링 지원)
+     * Redis Key: freelancer:project:list:{freelancerId}
+     * Expected value: List<Map<String, Object>> {
+     *     projectId, title, employerName, projectStatus, description, budget, techStack, startDate, endDate
+     * }
      */
-    public List<FreelancerAppliedProjectListDto> getMyProjects(Long freelancerId, String statusFilter) {
-        String redisKey = "freelancer:project:applied:" + freelancerId;
+    public List<FreelancerProjectListDto> getMyProjects(Long freelancerId, String statusFilter) {
+        String redisKey = "freelancer:project:list:" + freelancerId;
         try {
             Object rawData = redisTemplate.opsForValue().get(redisKey);
             if (rawData == null) {
@@ -58,7 +60,7 @@ public class FreelancerProjectService {
             return rawList.stream()
                     .map(data -> {
                         try {
-                            return toAppliedProjectDto(data);
+                            return toProjectDto(data);
                         } catch (Exception e) {
                             log.error("Failed to parse individual project item for freelancerId: {}", freelancerId, e);
                             return null;
@@ -66,24 +68,41 @@ public class FreelancerProjectService {
                     })
                     .filter(Objects::nonNull)
                     .filter(dto -> statusFilter == null || statusFilter.isBlank()
-                            || Objects.equals(dto.applyStatus(), statusFilter))
+                            || Objects.equals(dto.projectStatus(), statusFilter))
                     .toList();
         } catch (Exception e) {
-            log.error("Failed to parse freelancer applied project list from Redis for freelancerId: {}", freelancerId, e);
+            log.error("Failed to parse freelancer project list from Redis for freelancerId: {}", freelancerId, e);
             return Collections.emptyList();
         }
     }
 
-    private FreelancerAppliedProjectListDto toAppliedProjectDto(Map<String, Object> data) {
+    private FreelancerProjectListDto toProjectDto(Map<String, Object> data) {
         if (data == null) return null;
         Long projectId = data.get("projectId") != null
                 ? Long.valueOf(data.get("projectId").toString()) : null;
         String title = data.get("title") != null ? data.get("title").toString() : null;
         String employerName = data.get("employerName") != null ? data.get("employerName").toString() : null;
-        String applyStatus = data.get("applyStatus") != null ? data.get("applyStatus").toString() : null;
-        Long appliedAt = data.get("appliedAt") != null
-                ? Long.valueOf(data.get("appliedAt").toString()) : null;
+        String projectStatus = data.get("projectStatus") != null ? data.get("projectStatus").toString() : null;
+        String description = data.get("description") != null ? data.get("description").toString() : null;
+        Long budget = data.get("budget") != null
+                ? Long.valueOf(data.get("budget").toString()) : null;
+        @SuppressWarnings("unchecked")
+        List<String> techStack = data.get("techStack") instanceof List<?> rawList
+                ? rawList.stream().filter(Objects::nonNull).map(Object::toString).toList()
+                : List.of();
+        String startDate = data.get("startDate") != null ? data.get("startDate").toString() : null;
+        String endDate = data.get("endDate") != null ? data.get("endDate").toString() : null;
 
-        return new FreelancerAppliedProjectListDto(projectId, title, employerName, applyStatus, appliedAt);
+        return new FreelancerProjectListDto(
+                projectId,
+                title,
+                employerName,
+                projectStatus,
+                description,
+                budget,
+                techStack,
+                startDate,
+                endDate
+        );
     }
 }

--- a/freebridge/user/src/main/java/com/fallguys/mypage/service/freelancer/FreelancerReviewService.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/service/freelancer/FreelancerReviewService.java
@@ -47,16 +47,19 @@ public class FreelancerReviewService {
         Integer topPercentile = getTopPercentile(userId);
 
         if (freelancerId == null) {
+          log.warn("프리랜서 리뷰 요약 캐시 생성을 건너뜁니다. freelancerId를 찾지 못했습니다. userId={}", userId);
           return FreelancerEvaluationSummaryDto.empty(topPercentile);
-          }
+        }
 
         String redisKey = "freelancer:review:rates:" + freelancerId;
 
         try {
             Object rawData = redisTemplate.opsForValue().get(redisKey);
             if (rawData == null) {
+                log.info("프리랜서 리뷰 요약 Redis miss. userId={}, freelancerId={}, key={}", userId, freelancerId, redisKey);
                 return buildAndCacheReviewSummary(freelancerId, topPercentile, redisKey);
             }
+            log.info("프리랜서 리뷰 요약 Redis hit. userId={}, freelancerId={}, key={}", userId, freelancerId, redisKey);
             if (rawData instanceof Map<?, ?> rawMap) {
                 @SuppressWarnings("unchecked")
                 Map<String, Object> averages = (Map<String, Object>) rawMap;
@@ -98,6 +101,7 @@ public class FreelancerReviewService {
 
         Object[] row = (Object[]) query.getSingleResult();
         if (row == null || isAllNull(row)) {
+            cacheFreelancerReviewSummary(redisKey, Map.of());
             return FreelancerEvaluationSummaryDto.empty(topPercentile);
         }
 
@@ -109,16 +113,22 @@ public class FreelancerReviewService {
         averages.put("schedule", round1(numberValue(row[4])));
         averages.put("dispute", round1(numberValue(row[5])));
 
-        try {
-            redisTemplate.opsForValue().set(redisKey, averages);
-        } catch (Exception e) {
-            log.warn("프리랜서 리뷰 요약을 Redis에 저장하지 못했습니다. freelancerId={}", freelancerId, e);
-        }
-
+        cacheFreelancerReviewSummary(redisKey, averages);
         return FreelancerEvaluationSummaryDto.fromAverageMap(averages, topPercentile);
     }
 
+    private void cacheFreelancerReviewSummary(String redisKey, Map<String, Object> averages) {
+        try {
+            redisTemplate.opsForValue().set(redisKey, averages);
+            log.info("프리랜서 리뷰 요약 Redis 저장 완료. key={}, empty={}", redisKey, averages.isEmpty());
+        } catch (Exception e) {
+            log.warn("프리랜서 리뷰 요약을 Redis에 저장하지 못했습니다. key={}", redisKey, e);
+        }
+    }
+
     public FreelancerAiReputationReportDto getAiReputationReport(Long userId) {
+        getReviewSummary(userId);
+
         Long freelancerId = resolveFreelancerId(userId);
         if (freelancerId == null) {
             log.warn("해당 userId에 대한 프리랜서 엔티티를 찾지 못했습니다. userId={}", userId);

--- a/freebridge/user/src/main/java/com/fallguys/mypage/service/freelancer/FreelancerReviewService.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/service/freelancer/FreelancerReviewService.java
@@ -9,6 +9,8 @@ import com.fallguys.mypage.api.web.dto.freelancer.response.FreelancerEvaluationS
 import com.fallguys.mypage.api.web.dto.freelancer.response.FreelancerStrengthWeaknessDto;
 import com.fallguys.mypage.entity.freelancer.Freelancer;
 import com.fallguys.mypage.repository.freelancer.FreelancerRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -18,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
@@ -27,6 +30,7 @@ public class FreelancerReviewService {
 
     private final RedisTemplate<String, Object> redisTemplate;
     private final FreelancerRepository freelancerRepository;
+    private final EntityManager entityManager;
     private final ReviewEngine reviewEngine;
     private final ObjectMapper objectMapper;
 
@@ -51,7 +55,7 @@ public class FreelancerReviewService {
         try {
             Object rawData = redisTemplate.opsForValue().get(redisKey);
             if (rawData == null) {
-                return FreelancerEvaluationSummaryDto.empty(topPercentile);
+                return buildAndCacheReviewSummary(freelancerId, topPercentile, redisKey);
             }
             if (rawData instanceof Map<?, ?> rawMap) {
                 @SuppressWarnings("unchecked")
@@ -74,6 +78,44 @@ public class FreelancerReviewService {
             );
             return FreelancerEvaluationSummaryDto.empty(topPercentile);
         }
+    }
+
+    private FreelancerEvaluationSummaryDto buildAndCacheReviewSummary(Long freelancerId, Integer topPercentile, String redisKey) {
+        Query query = entityManager.createNativeQuery("""
+                SELECT
+                    AVG(language),
+                    AVG(framework),
+                    AVG(debugging),
+                    AVG(communication),
+                    AVG(schedule),
+                    AVG(dispute)
+                FROM employer_freelancer_reviews
+                WHERE freelancer_id = :freelancerId
+                  AND status = 'ACTIVE'
+                  AND deleted = false
+                """);
+        query.setParameter("freelancerId", freelancerId);
+
+        Object[] row = (Object[]) query.getSingleResult();
+        if (row == null || isAllNull(row)) {
+            return FreelancerEvaluationSummaryDto.empty(topPercentile);
+        }
+
+        Map<String, Object> averages = new HashMap<>();
+        averages.put("programming", round1(numberValue(row[0])));
+        averages.put("framework", round1(numberValue(row[1])));
+        averages.put("debugging", round1(numberValue(row[2])));
+        averages.put("communication", round1(numberValue(row[3])));
+        averages.put("schedule", round1(numberValue(row[4])));
+        averages.put("dispute", round1(numberValue(row[5])));
+
+        try {
+            redisTemplate.opsForValue().set(redisKey, averages);
+        } catch (Exception e) {
+            log.warn("프리랜서 리뷰 요약을 Redis에 저장하지 못했습니다. freelancerId={}", freelancerId, e);
+        }
+
+        return FreelancerEvaluationSummaryDto.fromAverageMap(averages, topPercentile);
     }
 
     public FreelancerAiReputationReportDto getAiReputationReport(Long userId) {
@@ -211,5 +253,25 @@ public class FreelancerReviewService {
                 Collections.emptyList(),
                 Collections.emptyList()
         );
+    }
+
+    private boolean isAllNull(Object[] row) {
+        for (Object value : row) {
+            if (value != null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private double numberValue(Object value) {
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        return 0.0;
+    }
+
+    private double round1(double value) {
+        return Math.round(value * 10.0) / 10.0;
     }
 }

--- a/freebridge/user/src/test/java/com/fallguys/mypage/service/employer/EmployerReviewServiceTest.java
+++ b/freebridge/user/src/test/java/com/fallguys/mypage/service/employer/EmployerReviewServiceTest.java
@@ -1,8 +1,11 @@
 package com.fallguys.mypage.service.employer;
 
 import com.fallguys.common.ai.port.ReviewEngine;
-import com.fallguys.mypage.api.web.dto.employer.response.EmployerReputationAiResponseDto;
 import com.fallguys.mypage.api.web.dto.employer.response.EmployerReviewSummaryResponseDto;
+import com.fallguys.mypage.entity.employer.Employer;
+import com.fallguys.mypage.repository.employer.EmployerRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +35,15 @@ class EmployerReviewServiceTest {
     @Mock
     private ReviewEngine reviewEngine;
 
+    @Mock
+    private EmployerRepository employerRepository;
+
+    @Mock
+    private EntityManager entityManager;
+
+    @Mock
+    private Query query;
+
     @Captor
     private ArgumentCaptor<List<Integer>> scoresCaptor;
 
@@ -47,6 +59,7 @@ class EmployerReviewServiceTest {
         // Given
         Long employerId = 1L;
         String redisKey = "employer:review:rates:" + employerId;
+        Employer employer = mock(Employer.class);
         
         // Mocking Data: List of Review Maps or DTOs.
         // 예를 들어 Review 도메인이 Redis에 아래와 같은 포맷으로 리뷰 점수 리스트를 올렸다고 가정합니다.
@@ -56,6 +69,8 @@ class EmployerReviewServiceTest {
             Map.of("atmosphereRate", 4, "requirementsDetailRate", 4.0, "scheduleAdherenceRate", 4)
         );
 
+        when(employer.getEmployerId()).thenReturn(employerId);
+        when(employerRepository.findByUserId(employerId)).thenReturn(java.util.Optional.of(employer));
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.get(redisKey)).thenReturn(mockReviews);
 
@@ -83,18 +98,29 @@ class EmployerReviewServiceTest {
         // Given
         Long employerId = 2L;
         String redisKey = "employer:review:rates:" + employerId;
+        Employer employer = mock(Employer.class);
         
+        when(employer.getEmployerId()).thenReturn(employerId);
+        when(employerRepository.findByUserId(employerId)).thenReturn(java.util.Optional.of(employer));
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.get(redisKey)).thenReturn(null);
+        when(entityManager.createNativeQuery(anyString())).thenReturn(query);
+        when(query.setParameter("employerId", employerId)).thenReturn(query);
+        when(query.getResultList()).thenReturn(List.of(
+                new Object[]{5, 4.0, 5},
+                new Object[]{3.0, 4, 3.0},
+                new Object[]{4, 4.0, 4}
+        ));
 
         // When
         EmployerReviewSummaryResponseDto result = employerReviewService.getReputationSummary(employerId);
 
         // Then
-        assertEquals(0.0, result.atmosphereRate());
-        assertEquals(0.0, result.requirementsDetailRate());
-        assertEquals(0.0, result.scheduleAdherenceRate());
-        assertEquals(0.0, result.averageRate());
+        assertEquals(4.0, result.atmosphereRate());
+        assertEquals(4.0, result.requirementsDetailRate());
+        assertEquals(4.0, result.scheduleAdherenceRate());
+        assertEquals(4.0, result.averageRate());
+        verify(valueOperations).set(eq(redisKey), anyList());
     }
 
     @Test

--- a/freebridge/user/src/test/java/com/fallguys/mypage/service/freelancer/FreelancerProjectServiceTest.java
+++ b/freebridge/user/src/test/java/com/fallguys/mypage/service/freelancer/FreelancerProjectServiceTest.java
@@ -1,6 +1,6 @@
 package com.fallguys.mypage.service.freelancer;
 
-import com.fallguys.mypage.api.web.dto.freelancer.response.FreelancerAppliedProjectListDto;
+import com.fallguys.mypage.api.web.dto.freelancer.response.FreelancerProjectListDto;
 import com.fallguys.mypage.api.web.dto.freelancer.response.FreelancerProjectStatusStatsDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -85,25 +85,27 @@ class FreelancerProjectServiceTest {
     void getMyProjects_SuccessAndFiltered() {
         // given
         Long freelancerId = 1L;
-        String redisKey = "freelancer:project:applied:" + freelancerId;
+        String redisKey = "freelancer:project:list:" + freelancerId;
 
         List<Map<String, Object>> mockList = List.of(
                 Map.of("projectId", 201, "title", "Spring 백엔드 개발", "employerName", "ABC Corp",
-                        "applyStatus", "심사중", "appliedAt", 1740000000000L),
+                        "projectStatus", "IN_PROGRESS", "description", "백엔드 API 개발",
+                        "budget", 5000000L, "techStack", List.of("java", "spring"), "startDate", "2026-03-01", "endDate", "2026-06-30"),
                 Map.of("projectId", 202, "title", "React 프론트개발", "employerName", "XYZ Inc",
-                        "applyStatus", "합격", "appliedAt", 1740100000000L)
+                        "projectStatus", "COMPLETED", "description", "프론트엔드 개발",
+                        "budget", 4000000L, "techStack", List.of("react"), "startDate", "2026-01-01", "endDate", "2026-02-28")
         );
 
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.get(redisKey)).thenReturn(mockList);
 
         // when – "심사중" 필터
-        List<FreelancerAppliedProjectListDto> result = freelancerProjectService.getMyProjects(freelancerId, "심사중");
+        List<FreelancerProjectListDto> result = freelancerProjectService.getMyProjects(freelancerId, "IN_PROGRESS");
 
         // then
         assertThat(result).hasSize(1);
         assertThat(result.get(0).projectId()).isEqualTo(201L);
-        assertThat(result.get(0).applyStatus()).isEqualTo("심사중");
+        assertThat(result.get(0).projectStatus()).isEqualTo("IN_PROGRESS");
     }
 
     @Test
@@ -111,18 +113,18 @@ class FreelancerProjectServiceTest {
     void getMyProjects_NoFilter_ReturnsAll() {
         // given
         Long freelancerId = 1L;
-        String redisKey = "freelancer:project:applied:" + freelancerId;
+        String redisKey = "freelancer:project:list:" + freelancerId;
 
         List<Map<String, Object>> mockList = List.of(
-                Map.of("projectId", 201, "title", "프로젝트A", "employerName", "A사", "applyStatus", "심사중", "appliedAt", 1000L),
-                Map.of("projectId", 202, "title", "프로젝트B", "employerName", "B사", "applyStatus", "합격", "appliedAt", 2000L)
+                Map.of("projectId", 201, "title", "프로젝트A", "employerName", "A사", "projectStatus", "IN_PROGRESS"),
+                Map.of("projectId", 202, "title", "프로젝트B", "employerName", "B사", "projectStatus", "COMPLETED")
         );
 
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.get(redisKey)).thenReturn(mockList);
 
         // when
-        List<FreelancerAppliedProjectListDto> result = freelancerProjectService.getMyProjects(freelancerId, null);
+        List<FreelancerProjectListDto> result = freelancerProjectService.getMyProjects(freelancerId, null);
 
         // then
         assertThat(result).hasSize(2);
@@ -133,37 +135,37 @@ class FreelancerProjectServiceTest {
     void getMyProjects_Empty() {
         // given
         Long freelancerId = 3L;
-        String redisKey = "freelancer:project:applied:" + freelancerId;
+        String redisKey = "freelancer:project:list:" + freelancerId;
 
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.get(redisKey)).thenReturn(null);
 
         // when
-        List<FreelancerAppliedProjectListDto> result = freelancerProjectService.getMyProjects(freelancerId, null);
+        List<FreelancerProjectListDto> result = freelancerProjectService.getMyProjects(freelancerId, null);
 
         // then
         assertThat(result).isEmpty();
     }
 
     @Test
-    @DisplayName("[TDD] 6. 프리랜서 지원 프로젝트 목록 조회: Map 내에 applyStatus 키가 없어도 NPE 없이 null로 파싱한다")
-    void getMyProjects_MissingApplyStatusKey_ReturnsGracefully() {
+    @DisplayName("[TDD] 6. 프리랜서 프로젝트 목록 조회: Map 내에 projectStatus 키가 없어도 NPE 없이 null로 파싱한다")
+    void getMyProjects_MissingProjectStatusKey_ReturnsGracefully() {
         // given
         Long freelancerId = 1L;
-        String redisKey = "freelancer:project:applied:" + freelancerId;
+        String redisKey = "freelancer:project:list:" + freelancerId;
 
         List<Map<String, Object>> mockList = List.of(
-                Map.of("projectId", 301, "title", "키 누락 프로젝트", "employerName", "Z사", "appliedAt", 999L)
+                Map.of("projectId", 301, "title", "키 누락 프로젝트", "employerName", "Z사")
         );
 
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.get(redisKey)).thenReturn(mockList);
 
         // when (null 필터 → 전체 조회)
-        List<FreelancerAppliedProjectListDto> result = freelancerProjectService.getMyProjects(freelancerId, null);
+        List<FreelancerProjectListDto> result = freelancerProjectService.getMyProjects(freelancerId, null);
 
         // then
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).applyStatus()).isNull();
+        assertThat(result.get(0).projectStatus()).isNull();
     }
 }

--- a/freebridge/user/src/test/java/com/fallguys/mypage/service/freelancer/FreelancerReviewServiceTest.java
+++ b/freebridge/user/src/test/java/com/fallguys/mypage/service/freelancer/FreelancerReviewServiceTest.java
@@ -3,6 +3,8 @@ package com.fallguys.mypage.service.freelancer;
 import com.fallguys.mypage.api.web.dto.freelancer.response.FreelancerEvaluationSummaryDto;
 import com.fallguys.mypage.entity.freelancer.Freelancer;
 import com.fallguys.mypage.repository.freelancer.FreelancerRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +34,12 @@ class FreelancerReviewServiceTest {
     @Mock
     private FreelancerRepository freelancerRepository;
 
+    @Mock
+    private EntityManager entityManager;
+
+    @Mock
+    private Query query;
+
     @InjectMocks
     private FreelancerReviewService freelancerReviewService;
 
@@ -55,6 +63,7 @@ class FreelancerReviewServiceTest {
         );
 
         Freelancer mockFreelancer = mock(Freelancer.class);
+        given(mockFreelancer.getFreelancerId()).willReturn(userId);
         given(mockFreelancer.getTopPercentile()).willReturn(topPercentile);
         given(freelancerRepository.findByUserId(userId)).willReturn(Optional.of(mockFreelancer));
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
@@ -83,18 +92,23 @@ class FreelancerReviewServiceTest {
         String redisKey = "freelancer:review:rates:" + userId;
 
         Freelancer mockFreelancer = mock(Freelancer.class);
+        given(mockFreelancer.getFreelancerId()).willReturn(userId);
         given(mockFreelancer.getTopPercentile()).willReturn(30);
         given(freelancerRepository.findByUserId(userId)).willReturn(Optional.of(mockFreelancer));
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.get(redisKey)).willReturn(null);
+        given(entityManager.createNativeQuery(anyString())).willReturn(query);
+        given(query.setParameter("freelancerId", userId)).willReturn(query);
+        given(query.getSingleResult()).willReturn(new Object[]{4.0, 5.0, 3.0, 5.0, 4.0, 2.0});
 
         // when
         FreelancerEvaluationSummaryDto result = freelancerReviewService.getReviewSummary(userId);
 
         // then
-        assertThat(result.averageRate()).isEqualTo(0.0);
-        assertThat(result.expertiseRate()).isEqualTo(0.0);
+        assertThat(result.averageRate()).isEqualTo(4.3);
+        assertThat(result.expertiseRate()).isEqualTo(4.0);
         assertThat(result.topPercentile()).isEqualTo(30);
+        verify(valueOperations).set(eq(redisKey), any(Map.class));
     }
 
     @Test
@@ -105,6 +119,7 @@ class FreelancerReviewServiceTest {
         String redisKey = "freelancer:review:rates:" + userId;
 
         Freelancer mockFreelancer = mock(Freelancer.class);
+        given(mockFreelancer.getFreelancerId()).willReturn(userId);
         given(mockFreelancer.getTopPercentile()).willReturn(20);
         given(freelancerRepository.findByUserId(userId)).willReturn(Optional.of(mockFreelancer));
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
@@ -129,11 +144,7 @@ class FreelancerReviewServiceTest {
     void getReviewSummary_FreelancerNotFound_ReturnsFallback() {
         // given
         Long userId = 4L;
-        String redisKey = "freelancer:review:rates:" + userId;
-
         given(freelancerRepository.findByUserId(userId)).willReturn(Optional.empty());
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-        given(valueOperations.get(redisKey)).willReturn(null);
 
         // when
         FreelancerEvaluationSummaryDto result = freelancerReviewService.getReviewSummary(userId);


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #

## 📝 작업 내용
프리랜서 마이페이지 리뷰 요약 Redis를 조회 시 생성되는 cache-aside 방식으로 전환하고, 리뷰가 없거나 AI 분석 API가 먼저 호출되는 경우에도 캐시가 안정적으로 생성되도록 백엔드 로직을 보완했습니다.

## ✅ Changes
- 리뷰 생성/수정/삭제 시 프리랜서 리뷰 요약 Redis를 직접 갱신하지 않고 관련 키만 삭제하도록 변경
- 프리랜서 리뷰 요약 조회 시 Redis miss면 DB에서 평균 집계 후 Redis에 저장하도록 cache-aside 적용
- 리뷰가 없는 경우에도 빈 캐시를 생성하도록 처리
- AI 평판 분석 조회 전에 리뷰 요약 캐시를 선생성하도록 로직 추가
- Redis hit/miss 및 저장 여부를 확인할 수 있도록 로그 추가
- `./gradlew :user:compileJava`로 컴파일 검증 완료

## 📸 스크린샷 (선택)
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
- 프리랜서 리뷰 요약 Redis 키는 `freelancer:review:rates:{freelancerId}` 입니다.
- 이번 PR은 Redis 생성 방식 개선이며, 별도로 AI 분석 서버 `localhost:8000`이 내려가 있으면 AI 관련 API는 계속 실패할 수 있습니다.
- 전체 `:user:test`는 이번 변경과 무관한 기존 `EmployerProfileServiceTest` 컴파일 에러 때문에 끝까지 실행되지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 리뷰 캐시 관리 시스템을 최적화하여 캐시 무효화 전략으로 변경했습니다.
  * 고용주 및 프리랜서 리뷰 요약에 대한 캐싱 효율성을 개선했습니다.
  * 스마트한 캐시 무효화를 통해 전반적인 성능을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->