### PR TITLE
HFP-118 [fix] 채팅 계약표기 오류 수정

### DIFF
--- a/freebridge/chatting/src/main/java/com/fallguys/chatting/api/web/ChatRoomController.java
+++ b/freebridge/chatting/src/main/java/com/fallguys/chatting/api/web/ChatRoomController.java
@@ -74,7 +74,11 @@ public class ChatRoomController {
             @PathVariable String roomId,
             @RequestBody ChatRoomContractUpdateRequest request) {
         String userId = extractUserId(authHeader);
-        ChatRoomResponse response = chatRoomService.updateRoomContract(roomId, userId, request.getContractId());
+        ChatRoomResponse response = chatRoomService.updateRoomContract(
+                roomId,
+                userId,
+                request.getContractId(),
+                Boolean.TRUE.equals(request.getOverrideExisting()));
         return ResponseEntity.ok(response);
     }
 

--- a/freebridge/chatting/src/main/java/com/fallguys/chatting/api/web/dto/request/ChatRoomContractUpdateRequest.java
+++ b/freebridge/chatting/src/main/java/com/fallguys/chatting/api/web/dto/request/ChatRoomContractUpdateRequest.java
@@ -8,4 +8,5 @@ import lombok.NoArgsConstructor;
 public class ChatRoomContractUpdateRequest {
 
     private Long contractId;
+    private Boolean overrideExisting;
 }

--- a/freebridge/chatting/src/main/java/com/fallguys/chatting/service/ChatRoomService.java
+++ b/freebridge/chatting/src/main/java/com/fallguys/chatting/service/ChatRoomService.java
@@ -73,7 +73,8 @@ public class ChatRoomService {
         return ChatRoomResponse.from(savedRoom, buildParticipantPresence(savedRoom));
     }
 
-    public ChatRoomResponse updateRoomContract(String roomId, String participantId, Long contractId) {
+    public ChatRoomResponse updateRoomContract(String roomId, String participantId, Long contractId,
+            boolean overrideExisting) {
         ChatRoom room = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다: " + roomId));
 
@@ -89,7 +90,7 @@ public class ChatRoomService {
             log.warn("계약 ID 없이 채팅방 계약 연결 시도 - roomId: {}, participantId: {}", roomId, participantId);
             throw new IllegalArgumentException("연결할 계약 ID가 필요합니다.");
         }
-        if (room.getContractId() != null && !room.getContractId().equals(contractId)) {
+        if (room.getContractId() != null && !room.getContractId().equals(contractId) && !overrideExisting) {
             log.warn(
                     "기존 계약이 연결된 채팅방 덮어쓰기 시도 - roomId: {}, participantId: {}, currentContractId: {}, requestedContractId: {}",
                     roomId,
@@ -97,6 +98,14 @@ public class ChatRoomService {
                     room.getContractId(),
                     contractId);
             throw new IllegalArgumentException("이미 계약이 연결된 채팅방입니다. 기존 계약을 덮어쓸 수 없습니다.");
+        }
+        if (room.getContractId() != null && !room.getContractId().equals(contractId) && overrideExisting) {
+            log.info(
+                    "명시적 계약 재연결 수행 - roomId: {}, participantId: {}, previousContractId: {}, requestedContractId: {}",
+                    roomId,
+                    participantId,
+                    room.getContractId(),
+                    contractId);
         }
 
         if (!contractQuery.existsContract(contractId)) {

--- a/freebridge/contract/src/main/java/com/fallguys/contract/api/web/dto/ContractResponse.java
+++ b/freebridge/contract/src/main/java/com/fallguys/contract/api/web/dto/ContractResponse.java
@@ -17,6 +17,9 @@ public class ContractResponse {
     private String projectName;
     private Long freelancerId;
     private Long employerId;
+    private String relatedJobId;
+    private String relatedApplicationId;
+    private String relatedProposalId;
     private LocalDate startDate;
     private LocalDate endDate;
     private String status;

--- a/freebridge/contract/src/main/java/com/fallguys/contract/api/web/dto/ContractSummary.java
+++ b/freebridge/contract/src/main/java/com/fallguys/contract/api/web/dto/ContractSummary.java
@@ -14,6 +14,9 @@ public class ContractSummary {
     private String projectName;
     private Long freelancerId;
     private Long employerId;
+    private String relatedJobId;
+    private String relatedApplicationId;
+    private String relatedProposalId;
     private LocalDate startDate;
     private LocalDate endDate;
     private String status;

--- a/freebridge/contract/src/main/java/com/fallguys/contract/api/web/dto/CreateContractRequest.java
+++ b/freebridge/contract/src/main/java/com/fallguys/contract/api/web/dto/CreateContractRequest.java
@@ -3,6 +3,7 @@ package com.fallguys.contract.api.web.dto;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -23,10 +24,13 @@ public class CreateContractRequest {
 
     private String freelancerName;     // 계약서 PDF에 표시될 프리랜서 이름
 
+    @Size(max = 100, message = "relatedJobId는 100자를 초과할 수 없습니다.")
     private String relatedJobId;
 
+    @Size(max = 100, message = "relatedApplicationId는 100자를 초과할 수 없습니다.")
     private String relatedApplicationId;
 
+    @Size(max = 100, message = "relatedProposalId는 100자를 초과할 수 없습니다.")
     private String relatedProposalId;
 
     @NotNull(message = "계약 시작일은 필수입니다.")

--- a/freebridge/contract/src/main/java/com/fallguys/contract/api/web/dto/CreateContractRequest.java
+++ b/freebridge/contract/src/main/java/com/fallguys/contract/api/web/dto/CreateContractRequest.java
@@ -23,6 +23,12 @@ public class CreateContractRequest {
 
     private String freelancerName;     // 계약서 PDF에 표시될 프리랜서 이름
 
+    private String relatedJobId;
+
+    private String relatedApplicationId;
+
+    private String relatedProposalId;
+
     @NotNull(message = "계약 시작일은 필수입니다.")
     private LocalDate startDate;
 

--- a/freebridge/contract/src/main/java/com/fallguys/contract/entity/Contract.java
+++ b/freebridge/contract/src/main/java/com/fallguys/contract/entity/Contract.java
@@ -30,6 +30,15 @@ public class Contract {
     private Long freelancerId;
     private Long employerId;
 
+    @Column(length = 100)
+    private String relatedJobId;
+
+    @Column(length = 100)
+    private String relatedApplicationId;
+
+    @Column(length = 100)
+    private String relatedProposalId;
+
     private LocalDate startDate;
     private LocalDate endDate;
 

--- a/freebridge/contract/src/main/java/com/fallguys/contract/repository/ContractRepository.java
+++ b/freebridge/contract/src/main/java/com/fallguys/contract/repository/ContractRepository.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 @Repository
 public interface ContractRepository extends JpaRepository<Contract, Long> {
 
+    boolean existsByContractId(Long contractId);
+
     Optional<Contract> findByContractId(Long contractId);
 
     List<Contract> findByEmployerIdOrderByIdDesc(Long employerId);

--- a/freebridge/contract/src/main/java/com/fallguys/contract/service/ContractQueryService.java
+++ b/freebridge/contract/src/main/java/com/fallguys/contract/service/ContractQueryService.java
@@ -18,7 +18,7 @@ public class ContractQueryService implements ContractQuery {
 
     @Override
     public boolean existsContract(Long contractId) {
-        return contractRepository.existsById(contractId);
+        return contractRepository.existsByContractId(contractId) || contractRepository.existsById(contractId);
     }
 
     @Override

--- a/freebridge/contract/src/main/java/com/fallguys/contract/service/ContractQueryService.java
+++ b/freebridge/contract/src/main/java/com/fallguys/contract/service/ContractQueryService.java
@@ -18,12 +18,12 @@ public class ContractQueryService implements ContractQuery {
 
     @Override
     public boolean existsContract(Long contractId) {
-        return contractRepository.existsByContractId(contractId) || contractRepository.existsById(contractId);
+        return contractRepository.existsByContractId(contractId);
     }
 
     @Override
     public ContractInfo getContractInfo(Long contractId) {
-        var c = contractRepository.findById(contractId)
+        var c = contractRepository.findByContractId(contractId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CONTRACT_NOT_FOUND));
 
         return new ContractInfo(

--- a/freebridge/contract/src/main/java/com/fallguys/contract/service/ContractService.java
+++ b/freebridge/contract/src/main/java/com/fallguys/contract/service/ContractService.java
@@ -43,6 +43,9 @@ public class ContractService {
         contract.setProjectName(req.getProjectName());
         contract.setFreelancerId(req.getFreelancerId());
         contract.setEmployerId(employerId);
+        contract.setRelatedJobId(req.getRelatedJobId());
+        contract.setRelatedApplicationId(req.getRelatedApplicationId());
+        contract.setRelatedProposalId(req.getRelatedProposalId());
         contract.setStartDate(req.getStartDate());
         contract.setEndDate(req.getEndDate());
         contract.setBudget(req.getBudget());
@@ -271,6 +274,9 @@ public class ContractService {
                 .projectName(c.getProjectName())
                 .freelancerId(c.getFreelancerId())
                 .employerId(c.getEmployerId())
+                .relatedJobId(c.getRelatedJobId())
+                .relatedApplicationId(c.getRelatedApplicationId())
+                .relatedProposalId(c.getRelatedProposalId())
                 .startDate(c.getStartDate())
                 .endDate(c.getEndDate())
                 .status(c.getStatus() != null ? c.getStatus().name() : null)
@@ -310,6 +316,9 @@ public class ContractService {
                 .projectName(c.getProjectName())
                 .freelancerId(c.getFreelancerId())
                 .employerId(c.getEmployerId())
+                .relatedJobId(c.getRelatedJobId())
+                .relatedApplicationId(c.getRelatedApplicationId())
+                .relatedProposalId(c.getRelatedProposalId())
                 .startDate(c.getStartDate())
                 .endDate(c.getEndDate())
                 .status(c.getStatus() != null ? c.getStatus().name() : null)

--- a/freebridge/contract/src/test/java/com/fallguys/contract/service/ContractQueryServiceTest.java
+++ b/freebridge/contract/src/test/java/com/fallguys/contract/service/ContractQueryServiceTest.java
@@ -16,6 +16,9 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,12 +49,25 @@ class ContractQueryServiceTest {
     }
 
     @Test
-    @DisplayName("getContractInfo()는 계약 정보를 ContractInfo로 변환하여 반환한다")
+    @DisplayName("existsContract()는 비즈니스 계약번호로만 계약 존재 여부를 확인한다")
+    void existsContract_checksBusinessContractIdOnly() {
+        when(contractRepository.existsByContractId(1001L))
+                .thenReturn(true);
+
+        boolean result = contractQueryService.existsContract(1001L);
+
+        assertTrue(result);
+        verify(contractRepository).existsByContractId(1001L);
+        verify(contractRepository, never()).existsById(anyLong());
+    }
+
+    @Test
+    @DisplayName("getContractInfo()는 비즈니스 계약번호로 계약 정보를 조회하여 반환한다")
     void getContractInfo_returnsContractInfo() {
-        when(contractRepository.findById(1L))
+        when(contractRepository.findByContractId(1001L))
                 .thenReturn(Optional.of(contract));
 
-        ContractInfo result = contractQueryService.getContractInfo(1L);
+        ContractInfo result = contractQueryService.getContractInfo(1001L);
 
         assertNotNull(result);
         assertEquals(1L, result.id());
@@ -67,9 +83,9 @@ class ContractQueryServiceTest {
     }
 
     @Test
-    @DisplayName("getContractInfo()는 존재하지 않는 계약 조회 시 예외를 발생시킨다")
+    @DisplayName("getContractInfo()는 존재하지 않는 비즈니스 계약번호 조회 시 예외를 발생시킨다")
     void getContractInfo_throwsExceptionWhenContractNotFound() {
-        when(contractRepository.findById(999L))
+        when(contractRepository.findByContractId(999L))
                 .thenReturn(Optional.empty());
 
         RuntimeException exception = assertThrows(
@@ -81,19 +97,20 @@ class ContractQueryServiceTest {
     }
 
     @Test
-    @DisplayName("getContractInfo()는 모든 필드가 null인 경우에도 동작한다")
+    @DisplayName("getContractInfo()는 모든 필드가 null인 경우에도 비즈니스 계약번호로 동작한다")
     void getContractInfo_handlesNullFields() {
         Contract emptyContract = new Contract();
         emptyContract.setId(2L);
+        emptyContract.setContractId(1002L);
 
-        when(contractRepository.findById(2L))
+        when(contractRepository.findByContractId(1002L))
                 .thenReturn(Optional.of(emptyContract));
 
-        ContractInfo result = contractQueryService.getContractInfo(2L);
+        ContractInfo result = contractQueryService.getContractInfo(1002L);
 
         assertNotNull(result);
         assertEquals(2L, result.id());
-        assertNull(result.contractId());
+        assertEquals(1002L, result.contractId());
         assertNull(result.projectName());
     }
 }

--- a/freebridge/contract/src/test/java/com/fallguys/contract/service/ContractServiceTest.java
+++ b/freebridge/contract/src/test/java/com/fallguys/contract/service/ContractServiceTest.java
@@ -51,6 +51,9 @@ class ContractServiceTest {
         createRequest = new CreateContractRequest();
         createRequest.setProjectName("테스트 프로젝트");
         createRequest.setFreelancerId(100L);
+        createRequest.setRelatedJobId("job-123");
+        createRequest.setRelatedApplicationId("app-456");
+        createRequest.setRelatedProposalId("proposal-789");
         createRequest.setStartDate(LocalDate.of(2024, 1, 1));
         createRequest.setEndDate(LocalDate.of(2024, 12, 31));
         createRequest.setBudget(5000000L);
@@ -102,6 +105,9 @@ class ContractServiceTest {
             assertEquals("테스트 프로젝트", response.getProjectName());
             assertEquals(100L, response.getFreelancerId());
             assertEquals(200L, response.getEmployerId());
+            assertEquals("job-123", response.getRelatedJobId());
+            assertEquals("app-456", response.getRelatedApplicationId());
+            assertEquals("proposal-789", response.getRelatedProposalId());
             assertEquals(5000000L, response.getBudget());
             assertEquals("WAITING_SIGNATURE", response.getStatus());
         }


### PR DESCRIPTION
## 🔗 Related Issue
> 이슈 번호를 작성해주세요. (예: Closes #123)
- Closes #203 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

## ✅ Changes
> 주요 변경 사항을 bullet point로 정리합니다.

## 📸 스크린샷 (선택)
> UI 변경 사항이나 테스트 결과 화면이 있다면 첨부해주세요.
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
> 리뷰 시 유의할 점, 후속 PR 예정 사항, 배포 영향 등을 적습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채팅룸에서 기존 계약을 덮어쓸지 선택할 수 있는 옵션이 추가되었습니다.
  * 계약에 관련된 외부 참조(관련 채용, 지원, 제안) ID가 생성/조회/응답에 노출됩니다.

* **개선 사항**
  * 계약 존재 검사 및 조회가 비즈니스 계약 ID 기준으로 일관화되어 정확도가 향상되었습니다.

* **테스트**
  * 비즈니스 계약 ID 기반 동작을 검증하도록 테스트들이 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->