### PR TITLE
HFP-96 fix: 계약 API 응답에 고용주 회사명과 사용자 실명 반영

### DIFF
--- a/freebridge/contract/build.gradle
+++ b/freebridge/contract/build.gradle
@@ -7,6 +7,7 @@ description = 'contract'
 dependencies {
     implementation project(':common')
     implementation project(':infra-common')
+    implementation project(':user')
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/freebridge/contract/src/main/java/com/fallguys/contract/service/ContractService.java
+++ b/freebridge/contract/src/main/java/com/fallguys/contract/service/ContractService.java
@@ -8,6 +8,8 @@ import com.fallguys.contract.api.web.PaginationInfo;
 import com.fallguys.contract.entity.Contract;
 import com.fallguys.contract.entity.ContractStatus;
 import com.fallguys.contract.repository.ContractRepository;
+import com.fallguys.mypage.repository.employer.EmployerRepository;
+import com.fallguys.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -32,6 +34,8 @@ public class ContractService {
     private final ContractRepository contractRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final ContractPdfService contractPdfService;
+    private final UserRepository userRepository;
+    private final EmployerRepository employerRepository;
 
 
     public ContractResponse createContract(CreateContractRequest req, Long employerId) {
@@ -237,10 +241,27 @@ public class ContractService {
         }
     }
 
-    // TODO: 유저 모듈 완성되면 api 콜로 수정하기
-    private String getMockUserName(Long userId) {
-        if (userId == null) return null;
-        return "사용자 #" + userId;
+    private String getFreelancerName(Long userId) {
+        if (userId == null) {
+            return null;
+        }
+
+        return userRepository.findById(userId)
+                .map(user -> user.getName())
+                .orElse("사용자 #" + userId);
+    }
+
+    private String getEmployerDisplayName(Long employerId) {
+        if (employerId == null) {
+            return null;
+        }
+
+        return employerRepository.findByUserId(employerId)
+                .map(employer -> employer.getCompanyName())
+                .filter(name -> name != null && !name.isBlank())
+                .orElseGet(() -> userRepository.findById(employerId)
+                        .map(user -> user.getName())
+                        .orElse("사용자 #" + employerId));
     }
 
     private ContractResponse toResponse(Contract c) {
@@ -277,8 +298,8 @@ public class ContractService {
                 .employerSignedDate(c.getEmployerSignedDate())
                 .freelancerSignature(c.getFreelancerSignature())
                 .freelancerSignedDate(c.getFreelancerSignedDate())
-                .freelancerName(getMockUserName(c.getFreelancerId()))
-                .employerName(getMockUserName(c.getEmployerId()))
+                .freelancerName(getFreelancerName(c.getFreelancerId()))
+                .employerName(getEmployerDisplayName(c.getEmployerId()))
                 .build();
     }
 
@@ -295,8 +316,8 @@ public class ContractService {
                 .budget(c.getBudget())
                 .employerSigned(c.getEmployerSignature() != null)
                 .freelancerSigned(c.getFreelancerSignature() != null)
-                .freelancerName(getMockUserName(c.getFreelancerId()))
-                .employerName(getMockUserName(c.getEmployerId()))
+                .freelancerName(getFreelancerName(c.getFreelancerId()))
+                .employerName(getEmployerDisplayName(c.getEmployerId()))
                 .build();
     }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #

## 📝 작업 내용
계약 API가 사용자 이름을 mock 문자열(`사용자 #id`)로 반환하던 문제를 수정했습니다. 프리랜서 후기 작성 화면 등 계약 정보를 참조하는 기능에서 실제 고용주 회사명과 사용자명이 표시되도록 백엔드 응답 로직을 보완했습니다.

## ✅ Changes
- `contract` 모듈에 `user` 모듈 의존성 추가
- 계약 목록/상세 응답 생성 시 mock 사용자명 생성 로직 제거
- 프리랜서 이름은 `UserRepository`를 통해 실제 사용자명으로 조회하도록 수정
- 고용주 이름은 `EmployerRepository.findByUserId()`를 통해 회사명을 우선 조회하도록 수정
- 회사명이 없을 경우 사용자명, 그마저 없을 경우 fallback 문자열을 사용하도록 응답 로직 보완

## 📸 스크린샷 (선택)
> UI 변경 사항이나 테스트 결과 화면이 있다면 첨부해주세요.
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
- 이번 PR은 계약 API 응답의 이름 매핑 로직 수정이 핵심입니다.
- `/api/contracts`, `/api/contracts/{id}` 를 사용하는 화면 전반에 표시값이 반영될 수 있습니다.
- 테스트 및 서버 재기동 후 계약 목록/상세, 후기 작성 대상 기업명 표시를 함께 확인하는 것이 좋습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* 계약 정보에 표시되는 프리랜서 및 고용주의 이름이 개선되었습니다. 이제 시스템에 저장된 실제 사용자 정보를 기반으로 정확한 이름이 표시되므로, 임시 데이터로 인한 혼동이 없어집니다. 이를 통해 계약 정보의 신뢰성이 향상되고, 계약 관리와 추적이 더욱 명확하고 효율적으로 진행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->