### PR TITLE
HFP-116 [feat] 구독 정책 및 로직 변경 서비스 & TDD

### DIFF
--- a/freebridge/app-main/src/main/java/com/fallguys/appmain/adapter/ExternalPaymentPortImpl.java
+++ b/freebridge/app-main/src/main/java/com/fallguys/appmain/adapter/ExternalPaymentPortImpl.java
@@ -5,11 +5,9 @@ import com.fallguys.common.api.payment.SubscriptionPaymentResult;
 import com.fallguys.subscription.api.shared.ExternalPaymentPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
-import java.util.Arrays;
 
 /**
  * user 모듈(subscription)에서 정의한 ExternalPaymentPort를 구현하고,
@@ -20,20 +18,10 @@ import java.util.Arrays;
 @RequiredArgsConstructor
 public class ExternalPaymentPortImpl implements ExternalPaymentPort {
 
-    // private final SubscriptionPaymentQuery subscriptionPaymentQuery; // TODO: payment 모듈 구현 완료 시 주입
-    private final Environment environment;
+    private final SubscriptionPaymentQuery subscriptionPaymentQuery;
 
     @Override
     public PaymentResult requestSubscriptionPayment(Long employerId, String planType, long amount, String billingKey) {
-        if (!isStubEnabled()) {
-            log.error("[ExternalPaymentPortImpl] Stub payment disabled in this environment.");
-            return new PaymentResult(false, null, "STUB_DISABLED", "Stub payment disabled in this environment");
-        }
-        log.warn("[ExternalPaymentPortImpl] 실제 결제 모듈(SubscriptionPaymentQuery) 미주입 상태입니다. Stub 결제로 처리합니다.");
-        log.info("[ExternalPaymentPortImpl] 결제 Stub 요청 (employerId: {}, planType: {}, amount: {})",
-                employerId, planType, amount);
-
-        /* TODO: payment 모듈 구현 완료 및 빈 등록 확인 시 아래 코드로 복구
         SubscriptionPaymentResult result = subscriptionPaymentQuery.processSubscriptionPayment(
                 employerId, planType, amount, billingKey
         );
@@ -48,33 +36,10 @@ public class ExternalPaymentPortImpl implements ExternalPaymentPort {
                 result.errorCode(),
                 result.errorMessage()
         );
-        */
-
-        // payment 모듈 미구현 상태에서 성공 Stub 반환
-        return new PaymentResult(
-                true,
-                Math.abs(java.util.UUID.randomUUID().getMostSignificantBits()), // 임시 billingId
-                null,
-                null
-        );
     }
 
     @Override
     public LocalDateTime getNextBillingDate(Long employerId) {
-        log.warn("[ExternalPaymentPortImpl] 실제 결제 모듈 미주입 상태입니다. Stub 결제일을 반환합니다.");
-
-        /* TODO: payment 모듈 구현 완료 후 아래 코드 사용
         return subscriptionPaymentQuery.getNextBillingDate(employerId);
-        */
-
-        // 결제 모듈 구현 전 임시로 다음달 1일 09시 반환
-        return LocalDateTime.now().plusMonths(1).withDayOfMonth(1).withHour(9).withMinute(0).withSecond(0).withNano(0);
-    }
-
-    private boolean isStubEnabled() {
-        boolean profileEnabled = Arrays.stream(environment.getActiveProfiles())
-                .anyMatch(profile -> "dev".equalsIgnoreCase(profile) || "test".equalsIgnoreCase(profile));
-        boolean propertyEnabled = Boolean.parseBoolean(environment.getProperty("payment.stub.enabled", "false"));
-        return profileEnabled || propertyEnabled;
     }
 }

--- a/freebridge/app-main/src/main/resources/application.yml
+++ b/freebridge/app-main/src/main/resources/application.yml
@@ -39,8 +39,8 @@ portone:
   channel-key: ${PORTONE_CHANNEL_KEY:test_channel_key}
   subscription:
     plan:
-      pro: ${PORTONE_SUBSCRIPTION_PLAN_PRO:19900}
-      prime: ${PORTONE_SUBSCRIPTION_PLAN_PRIME:39900}
+      pro: ${PORTONE_SUBSCRIPTION_PLAN_PRO:9900}
+      prime: ${PORTONE_SUBSCRIPTION_PLAN_PRIME:19900}
 
 fallguys:
   redis:

--- a/freebridge/common/src/main/java/com/fallguys/common/api/payment/SubscriptionPaymentQuery.java
+++ b/freebridge/common/src/main/java/com/fallguys/common/api/payment/SubscriptionPaymentQuery.java
@@ -64,4 +64,12 @@ public interface SubscriptionPaymentQuery {
      */
     SubscriptionUpgradeResult processSubscriptionUpgrade(
             Long employerId, String planType, long amount, String billingKey);
+
+    /**
+     * 현재 활성 billingKey 기준 다음 정기결제 예정일을 조회합니다.
+     *
+     * @param employerId 고용주 ID
+     * @return 다음 결제 예정일시, 없으면 null
+     */
+    java.time.LocalDateTime getNextBillingDate(Long employerId);
 }

--- a/freebridge/payment/src/main/java/com/fallguys/payment/entity/PlanType.java
+++ b/freebridge/payment/src/main/java/com/fallguys/payment/entity/PlanType.java
@@ -7,8 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PlanType {
     FREE(0L),
-    PRO(19900L),
-    PRIME(39900L);
+    PRO(9900L),
+    PRIME(19900L);
 
     /** 월 구독료 (KRW) */
     private final long monthlyPrice;

--- a/freebridge/payment/src/main/java/com/fallguys/payment/service/SubscriptionPaymentService.java
+++ b/freebridge/payment/src/main/java/com/fallguys/payment/service/SubscriptionPaymentService.java
@@ -453,4 +453,12 @@ public class SubscriptionPaymentService implements SubscriptionPaymentQuery {
                 nextBillingDate
         );
     }
+
+    @Override
+    public LocalDateTime getNextBillingDate(Long employerId) {
+        return billingKeyRepository
+                .findByEmployerIdAndActiveTrue(employerId)
+                .map(bk -> bk.getNextBillingDate().atTime(9, 0))
+                .orElse(null);
+    }
 }

--- a/freebridge/user/src/main/java/com/fallguys/mypage/api/shared/ExternalSubscriptionPortImpl.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/api/shared/ExternalSubscriptionPortImpl.java
@@ -71,25 +71,6 @@ public class ExternalSubscriptionPortImpl implements ExternalSubscriptionPort {
 
     @Override
     @Transactional
-    public void schedulePlanDowngrade(Long userId, PlanGrade targetGrade, LocalDateTime effectiveDate) {
-        Employer employer = getEmployerOrThrow(userId);
-
-        employer.scheduleSubscriptionChange(toSubscriptionEnum(targetGrade), effectiveDate);
-        log.info("[ExternalSubscriptionPortImpl] 다운그레이드 예약 등록 (userId: {}, current: {}, target: {}, effectiveDate: {})",
-                userId, employer.getSubscription(), targetGrade, effectiveDate);
-    }
-
-    @Override
-    @Transactional
-    public void cancelSubscription(Long userId, LocalDateTime effectiveDate) {
-        Employer employer = getEmployerOrThrow(userId);
-
-        employer.scheduleSubscriptionChange(Subscription.BASIC, effectiveDate);
-        log.info("[ExternalSubscriptionPortImpl] 구독 취소 예약 완료 (userId: {}, effectiveDate: {})", userId, effectiveDate);
-    }
-
-    @Override
-    @Transactional
     public void applyPendingSubscription(Long userId) {
         Employer employer = getEmployerOrThrow(userId);
         employer.applyPendingSubscription();

--- a/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/employer/request/UpdateSubscriptionRequestDto.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/employer/request/UpdateSubscriptionRequestDto.java
@@ -7,5 +7,7 @@ import jakarta.validation.constraints.Pattern;
 public record UpdateSubscriptionRequestDto(
         @NotBlank(message = "변경할 플랜을 입력해주세요.")
         @Pattern(regexp = "^(?i)(BASIC|PRO|PRIME)$", message = "유효하지 않은 플랜 값입니다. (BASIC, PRO, PRIME)")
-        String targetPlan
+        String targetPlan,
+
+        String billingKey
 ) {}

--- a/freebridge/user/src/main/java/com/fallguys/mypage/api/web/employer/EmployerAccountController.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/api/web/employer/EmployerAccountController.java
@@ -8,6 +8,7 @@ import com.fallguys.mypage.api.web.dto.employer.request.UpdateSubscriptionReques
 import com.fallguys.mypage.api.web.dto.employer.response.EmployerNotificationSettingsDto;
 import com.fallguys.common.security.CustomUserDetails;
 import com.fallguys.mypage.api.web.dto.employer.response.EmployerSubscriptionResponseDto;
+import com.fallguys.subscription.api.response.SubscriptionChangeResultResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -30,12 +31,12 @@ public class EmployerAccountController {
         return ApiResponse.ok(response);
     }
 
-    @Operation(summary = "구독 플랜 변경 신청", description = "프라임 멤버십 등 다른 플랜으로 변경을 요청합니다.")
+    @Operation(summary = "구독 플랜 변경 신청", description = "플랜 변경을 요청합니다. 업그레이드는 billingKey가 필요하며, 다운그레이드는 즉시 반영됩니다.")
     @PutMapping("/subscription")
-    public ApiResponse<Void> updateSubscription(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                @Valid @RequestBody UpdateSubscriptionRequestDto request) {
-        employerAccountService.updateSubscription(userDetails.getId(), request);
-        return ApiResponse.ok(null);
+    public ApiResponse<SubscriptionChangeResultResponse> updateSubscription(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                            @Valid @RequestBody UpdateSubscriptionRequestDto request) {
+        SubscriptionChangeResultResponse response = employerAccountService.updateSubscription(userDetails.getId(), request);
+        return ApiResponse.ok(response);
     }
 
     @Operation(summary = "비밀번호 변경", description = "고용주 계정의 비밀번호를 변경합니다.")

--- a/freebridge/user/src/main/java/com/fallguys/mypage/service/employer/EmployerAccountService.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/service/employer/EmployerAccountService.java
@@ -1,6 +1,9 @@
 package com.fallguys.mypage.service.employer;
 
 import com.fallguys.mypage.api.web.dto.employer.response.EmployerSubscriptionResponseDto;
+import com.fallguys.subscription.api.request.SubscriptionChangeRequest;
+import com.fallguys.subscription.api.response.SubscriptionChangeResultResponse;
+import com.fallguys.subscription.service.SubscriptionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -28,6 +31,7 @@ public class EmployerAccountService {
     private final RedisTemplate<String, Object> redisTemplate;
     private final EmployerRepository employerRepository;
     private final SharedMypageApi sharedMypageApi;
+    private final SubscriptionService subscriptionService;
 
     public void updatePassword(Long employerId, UpdatePasswordRequestDto request) {
         if (request == null || 
@@ -40,11 +44,14 @@ public class EmployerAccountService {
     }
 
     @Transactional
-    public void updateSubscription(Long userId, UpdateSubscriptionRequestDto request) {
+    public SubscriptionChangeResultResponse updateSubscription(Long userId, UpdateSubscriptionRequestDto request) {
         if (request == null || request.targetPlan() == null || request.targetPlan().isBlank()) {
             throw new IllegalArgumentException("변경할 구독 플랜 값이 필요합니다.");
         }
-        sharedMypageApi.updateSubscription(userId, request.targetPlan().toUpperCase());
+        return subscriptionService.changePlan(
+                userId,
+                new SubscriptionChangeRequest(request.targetPlan().toUpperCase(), request.billingKey())
+        );
     }
 
     public EmployerSubscriptionResponseDto getSubscription(Long userId) {

--- a/freebridge/user/src/main/java/com/fallguys/subscription/api/shared/ExternalSubscriptionPort.java
+++ b/freebridge/user/src/main/java/com/fallguys/subscription/api/shared/ExternalSubscriptionPort.java
@@ -40,23 +40,5 @@ public interface ExternalSubscriptionPort {
 
     void setNextBillingDate(Long userId, LocalDateTime nextBillingDate);
 
-    /**
-     * 다운그레이드 예약 (즉시 변경 아님).
-     * 현재 결제 주기(당월) 말까지 기존 플랜을 유지하고,
-     * 다음 결제일부터 targetGrade로 전환합니다.
-     * (예: PRIME → PRO: 이번 달은 PRIME 유지, 다음 달부터 PRO 청구)
-     *
-     * @param userId       예약 대상 사용자의 고유 ID
-     * @param targetGrade  다음 결제일에 적용할 목표 플랜 등급
-     */
-    void schedulePlanDowngrade(Long userId, PlanGrade targetGrade, LocalDateTime effectiveDate);
-
-    /**
-     * 구독을 취소하고 BASIC 플랜으로 전환 요청을 처리합니다.
-     *
-     * @param userId 고용주 회원 식별자
-     */
-    void cancelSubscription(Long userId, LocalDateTime effectiveDate);
-
     void applyPendingSubscription(Long userId);
 }

--- a/freebridge/user/src/main/java/com/fallguys/subscription/api/web/SubscriptionController.java
+++ b/freebridge/user/src/main/java/com/fallguys/subscription/api/web/SubscriptionController.java
@@ -15,10 +15,10 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 /**
- * 고용주(Employer) 구독 관리 REST Controller.
+ * 고용주 Employer 구독 관리 REST Controller.
  * <p>
- * 구독 조회, 플랜 변경, 구독 취소 API를 제공합니다.
- * 인증은 JWT를 통해 처리되며, {@link CustomUserDetails}에서 userId를 추출합니다.
+ * 구독 조회, 플랜 변경 API를 제공한다.
+ * 인증은 JWT를 통해 처리하고, {@link CustomUserDetails}에서 userId를 추출한다.
  */
 @Tag(name = "Employer Subscription", description = "고용주 구독 플랜 관리 API")
 @RestController
@@ -28,7 +28,7 @@ public class SubscriptionController {
 
     private final SubscriptionService subscriptionService;
 
-    @Operation(summary = "구독 정보 조회", description = "현재 구독 플랜, 수수료율, 월 구독료 등을 반환합니다.\n(다운그레이드 예약 시 예약 정보도 추후 제공될 수 있습니다.)")
+    @Operation(summary = "구독 정보 조회", description = "현재 구독 플랜, 수수료율, 월 구독료 등을 반환한다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "구독 정보 반환 성공")
     })
@@ -39,9 +39,9 @@ public class SubscriptionController {
         return ApiResponse.ok(response);
     }
 
-    @Operation(summary = "구독 플랜 변경", description = "플랜 변경 요청을 처리합니다.\n* 업그레이드(BASIC->PRO/PRIME): billingKey 필수, 결제는 스케줄러에서 처리\n* 다운그레이드(PRIME->PRO): 결제 없이 다음 결제일 전환 예약")
+    @Operation(summary = "구독 플랜 변경", description = "플랜 변경 요청을 처리한다.\n* 업그레이드(BASIC->PRO/PRIME, PRO->PRIME): billingKey 필수, 결제 성공 시 즉시 반영\n* 다운그레이드(PRIME->PRO, PRO/PRIME->BASIC): 경고 확인 후 즉시 반영")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "플랜 변경(또는 예약) 완료"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "플랜 변경 완료"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 플랜 값이거나 billingKey 누락"),
     })
     @PutMapping
@@ -49,18 +49,6 @@ public class SubscriptionController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody SubscriptionChangeRequest request) {
         SubscriptionChangeResultResponse response = subscriptionService.changePlan(userDetails.getId(), request);
-        return ApiResponse.ok(response);
-    }
-
-    @Operation(summary = "구독 취소", description = "구독을 해지하고 BASIC 플랜으로 전환합니다.")
-    @io.swagger.v3.oas.annotations.responses.ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "구독 취소 및 BASIC 전환 완료"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이미 BASIC 플랜 사용 중인 경우")
-    })
-    @DeleteMapping("/cancel")
-    public ApiResponse<SubscriptionChangeResultResponse> cancelSubscription(
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        SubscriptionChangeResultResponse response = subscriptionService.cancelSubscription(userDetails.getId());
         return ApiResponse.ok(response);
     }
 }

--- a/freebridge/user/src/main/java/com/fallguys/subscription/entity/PlanGrade.java
+++ b/freebridge/user/src/main/java/com/fallguys/subscription/entity/PlanGrade.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 public enum PlanGrade {
 
     BASIC(0, 12.0),
-    PRO(19900, 10.0),
-    PRIME(39900, 7.0);
+    PRO(9900, 10.0),
+    PRIME(19900, 7.0);
 
     private final int monthlyPrice;
     private final double feeRate;

--- a/freebridge/user/src/main/java/com/fallguys/subscription/service/SubscriptionService.java
+++ b/freebridge/user/src/main/java/com/fallguys/subscription/service/SubscriptionService.java
@@ -25,12 +25,4 @@ public interface SubscriptionService {
      */
     SubscriptionChangeResultResponse changePlan(Long userId, SubscriptionChangeRequest request);
 
-    /**
-     * 유료 구독을 취소하고 자동 결제를 해지합니다.
-     * 취소 시 즉시 BASIC 플랜으로 전환됩니다.
-     *
-     * @param userId 취소할 고용주의 사용자 ID
-     * @throws IllegalStateException 이미 BASIC 플랜인 경우 발생
-     */
-    SubscriptionChangeResultResponse cancelSubscription(Long userId);
 }

--- a/freebridge/user/src/main/java/com/fallguys/subscription/service/SubscriptionServiceImpl.java
+++ b/freebridge/user/src/main/java/com/fallguys/subscription/service/SubscriptionServiceImpl.java
@@ -63,10 +63,6 @@ public class SubscriptionServiceImpl implements SubscriptionService {
             throw new BusinessException(ErrorCode.SUBSCRIPTION_SAME_PLAN);
         }
 
-        if (targetGrade == PlanGrade.BASIC) {
-            throw new BusinessException(ErrorCode.SUBSCRIPTION_CANCEL_REQUIRED);
-        }
-
         boolean isUpgrade = targetGrade.ordinal() > currentGrade.ordinal();
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime nextBillingDate = resolveNextBillingDate(userId, now);
@@ -103,40 +99,23 @@ public class SubscriptionServiceImpl implements SubscriptionService {
             );
         }
 
-        nextBillingDate = resolveOrComputeMonthlyBillingDate(userId, now);
+        externalSubscriptionPort.changePlan(userId, targetGrade);
 
-        externalSubscriptionPort.schedulePlanDowngrade(userId, targetGrade, nextBillingDate);
-
-        return new SubscriptionChangeResultResponse(
-                currentGrade.name(),
-                targetGrade.name(),
-                "CHANGE_RESERVED",
-                nextBillingDate,
-                "Downgrade reserved for next billing date."
-        );
-    }
-
-    @Override
-    @Transactional
-    public SubscriptionChangeResultResponse cancelSubscription(Long userId) {
-        validateUserId(userId);
-        LocalDateTime now = LocalDateTime.now();
-
-        PlanGrade currentPlan = externalSubscriptionPort.getCurrentPlan(userId);
-        if (currentPlan == PlanGrade.BASIC) {
-            throw new BusinessException(ErrorCode.SUBSCRIPTION_ALREADY_BASIC);
+        if (targetGrade == PlanGrade.BASIC) {
+            nextBillingDate = null;
+            externalSubscriptionPort.setNextBillingDate(userId, null);
+        } else {
+            nextBillingDate = resolveOrComputeMonthlyBillingDate(userId, now);
         }
 
-        LocalDateTime nextBillingDate = resolveOrComputeMonthlyBillingDate(userId, now);
-
-        externalSubscriptionPort.cancelSubscription(userId, nextBillingDate);
-
         return new SubscriptionChangeResultResponse(
-                currentPlan.name(),
-                PlanGrade.BASIC.name(),
-                "CANCEL_RESERVED",
+                targetGrade.name(),
+                null,
+                "ACTIVE",
                 nextBillingDate,
-                "Cancellation reserved for next billing date."
+                targetGrade == PlanGrade.BASIC
+                        ? "Plan changed to BASIC immediately."
+                        : "Downgrade applied immediately."
         );
     }
 

--- a/freebridge/user/src/test/java/com/fallguys/mypage/service/employer/EmployerProfileServiceTest.java
+++ b/freebridge/user/src/test/java/com/fallguys/mypage/service/employer/EmployerProfileServiceTest.java
@@ -103,7 +103,8 @@ class EmployerProfileServiceTest {
                         "S30_99",
                         "Yeouido",
                         "https://new.com",
-                        "Updated Description"
+                        "Updated Description",
+                        "0108998932"
                 );
 
         // when
@@ -137,7 +138,8 @@ class EmployerProfileServiceTest {
                         "INVALID_SCALE",
                         "Yeouido",
                         "https://new.com",
-                        "Updated Description"
+                        "Updated Description",
+                        "0108998932"
                 );
 
         // when & then

--- a/freebridge/user/src/test/java/com/fallguys/subscription/service/SubscriptionServiceTest.java
+++ b/freebridge/user/src/test/java/com/fallguys/subscription/service/SubscriptionServiceTest.java
@@ -5,8 +5,8 @@ import com.fallguys.common.exception.ErrorCode;
 import com.fallguys.subscription.api.request.SubscriptionChangeRequest;
 import com.fallguys.subscription.api.response.SubscriptionChangeResultResponse;
 import com.fallguys.subscription.api.response.SubscriptionResponse;
-import com.fallguys.subscription.api.shared.ExternalSubscriptionPort;
 import com.fallguys.subscription.api.shared.ExternalPaymentPort;
+import com.fallguys.subscription.api.shared.ExternalSubscriptionPort;
 import com.fallguys.subscription.entity.PlanGrade;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,7 +39,7 @@ class SubscriptionServiceTest {
     private SubscriptionServiceImpl subscriptionService;
 
     @Test
-    @DisplayName("êµ¬ë… ì¡°íšŒ: PROë¡?ë³€ê²½ì‹œ, nextBillingDate?€ ?”ê¸ˆ ?•ë³´ê°€ ?•ìƒ ë°˜í™˜?œë‹¤.")
+    @DisplayName("구독 조회: PRO 플랜은 nextBillingDate를 함께 반환한다")
     void getSubscription_ProPlan_Success_WithBillingDate() {
         Long userId = 1L;
         LocalDateTime mockDate = LocalDateTime.of(2026, 4, 1, 9, 0);
@@ -51,14 +51,14 @@ class SubscriptionServiceTest {
 
         assertThat(result.planGrade()).isEqualTo("PRO");
         assertThat(result.feeRate()).isEqualTo(10.0);
-        assertThat(result.monthlyPrice()).isEqualTo(19900);
+        assertThat(result.monthlyPrice()).isEqualTo(9900);
         assertThat(result.nextBillingDate()).isEqualTo(mockDate);
 
         verify(externalSubscriptionPort, times(1)).getNextBillingDate(userId);
     }
 
     @Test
-    @DisplayName("êµ¬ë… ì¡°íšŒ: ë¹„ì–´?ˆëŠ” userID??ê²½ìš° Null Exception??ë°œìƒ?œí‚¨??")
+    @DisplayName("구독 조회: userId가 null이면 BusinessException이 발생한다")
     void getSubscription_NullUserId_ThrowsException() {
         assertThatThrownBy(() -> subscriptionService.getSubscription(null))
                 .isInstanceOf(BusinessException.class)
@@ -67,7 +67,7 @@ class SubscriptionServiceTest {
     }
 
     @Test
-    @DisplayName("êµ¬ë… ë³€ê²? ?™ì¼???Œëžœ?¼ë¡œ ë³€ê²???BusinessException???¼ìœ¼?¨ë‹¤.")
+    @DisplayName("플랜 변경: 동일한 플랜으로 요청하면 BusinessException이 발생한다")
     void changePlan_SamePlan_ThrowsException() {
         Long userId = 1L;
         SubscriptionChangeRequest request = new SubscriptionChangeRequest("PRO", "billing-key");
@@ -80,7 +80,7 @@ class SubscriptionServiceTest {
     }
 
     @Test
-    @DisplayName("êµ¬ë… ë³€ê²? ? íš¨?˜ì? ?Šì? ?Œëžœ?€ BusinessException???¼ìœ¼?¨ë‹¤.")
+    @DisplayName("플랜 변경: 유효하지 않은 플랜 값이면 BusinessException이 발생한다")
     void changePlan_InvalidPlanName_ThrowsException() {
         Long userId = 1L;
         SubscriptionChangeRequest request = new SubscriptionChangeRequest("GOLD", null);
@@ -113,12 +113,11 @@ class SubscriptionServiceTest {
         verify(externalSubscriptionPort).changePlan(userId, PlanGrade.PRO);
         verify(externalSubscriptionPort).saveBillingKey(userId, "billing-key-123");
         verify(externalSubscriptionPort).setNextBillingDate(anyLong(), any(LocalDateTime.class));
-        verify(externalSubscriptionPort, never()).schedulePlanDowngrade(anyLong(), any(), any());
     }
 
     @Test
-    @DisplayName("êµ¬ë… ë³€ê²?: ?¤ìš´ê·¸ë ˆ?´ë“œ reserves change for nextBillingDate")
-    void changePlan_Downgrade_PrimeToPro_ScheduledNoPayment() {
+    @DisplayName("다운그레이드: PRIME->PRO, 결제 없이 즉시 반영하고 nextBillingDate 유지")
+    void changePlan_Downgrade_PrimeToPro_ImmediateNoPayment() {
         Long userId = 1L;
         LocalDateTime mockDate = LocalDateTime.of(2026, 4, 1, 9, 0);
         SubscriptionChangeRequest request = new SubscriptionChangeRequest("PRO", null);
@@ -128,41 +127,33 @@ class SubscriptionServiceTest {
 
         SubscriptionChangeResultResponse result = subscriptionService.changePlan(userId, request);
 
-        assertThat(result.currentPlanGrade()).isEqualTo("PRIME");
-        assertThat(result.pendingPlanGrade()).isEqualTo("PRO");
-        assertThat(result.status()).isEqualTo("CHANGE_RESERVED");
-        assertThat(result.nextBillingDate()).isEqualTo(mockDate);
-
-        verify(externalSubscriptionPort).schedulePlanDowngrade(userId, PlanGrade.PRO, mockDate);
-    }
-
-    @Test
-    @DisplayName("êµ¬ë… ì·¨ì†Œ: reserves BASIC on nextBillingDate")
-    void cancelSubscription_ProPlan_ReservedToBasic() {
-        Long userId = 1L;
-        LocalDateTime mockDate = LocalDateTime.of(2026, 4, 1, 9, 0);
-        when(externalSubscriptionPort.getCurrentPlan(userId)).thenReturn(PlanGrade.PRO);
-        when(externalSubscriptionPort.getNextBillingDate(userId)).thenReturn(mockDate);
-
-        SubscriptionChangeResultResponse result = subscriptionService.cancelSubscription(userId);
-
         assertThat(result.currentPlanGrade()).isEqualTo("PRO");
-        assertThat(result.pendingPlanGrade()).isEqualTo("BASIC");
-        assertThat(result.status()).isEqualTo("CANCEL_RESERVED");
+        assertThat(result.pendingPlanGrade()).isNull();
+        assertThat(result.status()).isEqualTo("ACTIVE");
         assertThat(result.nextBillingDate()).isEqualTo(mockDate);
 
-        verify(externalSubscriptionPort, times(1)).cancelSubscription(userId, mockDate);
+        verify(externalSubscriptionPort).changePlan(userId, PlanGrade.PRO);
+        verify(externalPaymentPort, never()).requestSubscriptionPayment(anyLong(), any(), anyLong(), any());
     }
 
     @Test
-    @DisplayName("êµ¬ë… ì·¨ì†Œ: already BASIC throws BusinessException")
-    void cancelSubscription_AlreadyBasicPlan_ThrowsException() {
+    @DisplayName("다운그레이드: PRO->BASIC, changePlan으로 즉시 반영하고 nextBillingDate를 제거")
+    void changePlan_Downgrade_ProToBasic_ImmediateAndClearBillingDate() {
         Long userId = 1L;
-        when(externalSubscriptionPort.getCurrentPlan(userId)).thenReturn(PlanGrade.BASIC);
+        SubscriptionChangeRequest request = new SubscriptionChangeRequest("BASIC", null);
 
-        assertThatThrownBy(() -> subscriptionService.cancelSubscription(userId))
-                .isInstanceOf(BusinessException.class)
-                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
-                        .isEqualTo(ErrorCode.SUBSCRIPTION_ALREADY_BASIC));
+        when(externalSubscriptionPort.getCurrentPlan(userId)).thenReturn(PlanGrade.PRO);
+        when(externalSubscriptionPort.getNextBillingDate(userId)).thenReturn(LocalDateTime.of(2026, 4, 1, 9, 0));
+
+        SubscriptionChangeResultResponse result = subscriptionService.changePlan(userId, request);
+
+        assertThat(result.currentPlanGrade()).isEqualTo("BASIC");
+        assertThat(result.pendingPlanGrade()).isNull();
+        assertThat(result.status()).isEqualTo("ACTIVE");
+        assertThat(result.nextBillingDate()).isNull();
+
+        verify(externalSubscriptionPort).changePlan(userId, PlanGrade.BASIC);
+        verify(externalSubscriptionPort).setNextBillingDate(userId, null);
+        verify(externalPaymentPort, never()).requestSubscriptionPayment(anyLong(), any(), anyLong(), any());
     }
 }


### PR DESCRIPTION
## 🔗 Related Issue
> 이슈 번호를 작성해주세요. (예: Closes #123)
#194 

## 📝 작업 내용

- 고용주 구독 정책을 즉시 반영 기준으로 정리하고, subscription 도메인과 payment 도메인의 연결을 실제 결제 흐름에 맞게 보강
- 다운그레이드 정책을 예약 반영에서 즉시 반영으로 전환하고, BASIC 전환은 `changePlan()` 경로로 통합
- 구독 결제 가격 정책을 `PRO 9,900원 / PRIME 19,900원`으로 정리

## ✅ Changes

- 구독 다운그레이드 정책을 즉시 반영 기준으로 변경
- `changePlan(BASIC)` 허용
- `cancelSubscription()` 제거
- `PRIME -> PRO` 즉시 반영 및 `nextBillingDate` 유지
- `PRO/PRIME -> BASIC` 즉시 반영 및 `nextBillingDate = null`
- `pendingPlanGrade = null`, `status = ACTIVE` 기준으로 정리
- 고용주 계정관리 구독 변경 API를 `SubscriptionService.changePlan()`으로 연결
- 구독 변경 요청 DTO에 `billingKey` 추가
- `ExternalPaymentPortImpl`를 실제 payment 모듈로 연결
- 구독 가격 통일
  - `PRO 9,900원`
  - `PRIME 19,900원`
- 관련 테스트 및 문서 정리
- 
## ⚠️ Notes (Optional)
> 리뷰 시 유의할 점, 후속 PR 예정 사항, 배포 영향 등을 적습니다.

- `:app-main:build` 기준 빌드 성공 확인
- 로컬 환경에서는 PortOne billing 채널 계약 문제로 billingKey 발급 실패
- 서버 환경에서 billing 가능한 채널 기준으로 업그레이드 실결제 검증이 추가로 필요
- billingKey 재사용 구조는 후속 작업으로 검토 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 실시간 구독 요금제 변경 기능 추가

* **버그 수정**
  * PRO 요금제 월 가격 19,900원 → 9,900원으로 인하
  * PRIME 요금제 월 가격 39,900원 → 19,900원으로 인하

* **개선사항**
  * 결제 모듈 실제 구현으로 전환 (테스트 모드 제거)
  * 요금제 다운그레이드 즉시 적용 (예약 기능 제거)
  * 구독 관리 프로세스 간소화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->