### PR TITLE
Hfp 96 fix 마이페이지 리뷰 캐시 및 계약 이름 응답 로직 수정

### DIFF
--- a/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/employer/response/EmployerReviewSummaryResponseDto.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/employer/response/EmployerReviewSummaryResponseDto.java
@@ -52,11 +52,33 @@ public record EmployerReviewSummaryResponseDto(
         );
     }
 
+    public static EmployerReviewSummaryResponseDto fromAverageMap(Map<String, Object> averages) {
+        if (averages == null || averages.isEmpty()) {
+            return empty();
+        }
+
+        double avgAtmosphere = round1(safeNumber(averages.get("atmosphereRate")));
+        double avgRequirements = round1(safeNumber(averages.get("requirementsDetailRate")));
+        double avgSchedule = round1(safeNumber(averages.get("scheduleAdherenceRate")));
+        double totalAverage = round1((avgAtmosphere + avgRequirements + avgSchedule) / 3.0);
+
+        return new EmployerReviewSummaryResponseDto(
+                totalAverage,
+                avgAtmosphere,
+                avgRequirements,
+                avgSchedule
+        );
+    }
+
     /** Integer, Long, Double 등 모든 Number 하위 타입과 null을 안전하게 double로 변환합니다. */
     private static double safeNumber(Object value) {
         if (value instanceof Number n) {
             return n.doubleValue();
         }
         return 0.0;
+    }
+
+    private static double round1(double value) {
+        return Math.round(value * 10.0) / 10.0;
     }
 }

--- a/freebridge/user/src/main/java/com/fallguys/mypage/service/employer/EmployerProfileService.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/service/employer/EmployerProfileService.java
@@ -28,11 +28,13 @@ public class EmployerProfileService {
     private final EmployerRepository employerRepository;
     private final FileStorage fileStorage;
     private final ExternalUserApi externalUserApi;
+    private final EmployerReviewService employerReviewService;
 
     @Transactional(readOnly = true)
     public EmployerBasicProfileDto getProfile(Long userId) {
         Employer employer = employerRepository.findByUserId(userId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저의 고용주 프로필을 찾을 수 없습니다."));
+        employerReviewService.getReputationSummary(userId);
 
         ExternalUserMyInfoResponse userInfo = null;
         try {

--- a/freebridge/user/src/main/java/com/fallguys/mypage/service/employer/EmployerReviewService.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/service/employer/EmployerReviewService.java
@@ -10,9 +10,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
@@ -36,10 +36,19 @@ public class EmployerReviewService {
                 return buildAndCacheSummary(employerId, redisKey);
             }
 
-            @SuppressWarnings("unchecked")
-            List<Map<String, Object>> reviews = (List<Map<String, Object>>) rawData;
+            if (rawData instanceof Map<?, ?> rawMap) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> averages = (Map<String, Object>) rawMap;
+                return EmployerReviewSummaryResponseDto.fromAverageMap(averages);
+            }
 
-            return EmployerReviewSummaryResponseDto.from(reviews);
+            if (rawData instanceof List<?> rawList) {
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> reviews = (List<Map<String, Object>>) rawList;
+                return EmployerReviewSummaryResponseDto.from(reviews);
+            }
+
+            return EmployerReviewSummaryResponseDto.empty();
 
         } catch (Exception e) {
             log.error("Failed to parse employer review summary from Redis for employerId: {}", userId, e);
@@ -60,24 +69,32 @@ public class EmployerReviewService {
         @SuppressWarnings("unchecked")
         List<Object[]> rows = query.getResultList();
         if (rows == null || rows.isEmpty()) {
-            cacheEmployerReviewSummary(redisKey, List.of());
+            cacheEmployerReviewSummary(redisKey, Map.of());
             return EmployerReviewSummaryResponseDto.empty();
         }
 
-        List<Map<String, Object>> payload = new ArrayList<>(rows.size());
+        double sumAtmosphere = 0.0;
+        double sumRequirements = 0.0;
+        double sumSchedule = 0.0;
+        int count = 0;
+
         for (Object[] row : rows) {
-            payload.add(Map.of(
-                    "atmosphereRate", numberValue(row[0]),
-                    "requirementsDetailRate", numberValue(row[1]),
-                    "scheduleAdherenceRate", numberValue(row[2])
-            ));
+            sumAtmosphere += numberValue(row[0]);
+            sumRequirements += numberValue(row[1]);
+            sumSchedule += numberValue(row[2]);
+            count++;
         }
 
-        cacheEmployerReviewSummary(redisKey, payload);
-        return EmployerReviewSummaryResponseDto.from(payload);
+        Map<String, Object> averages = new HashMap<>();
+        averages.put("atmosphereRate", round1(sumAtmosphere / count));
+        averages.put("requirementsDetailRate", round1(sumRequirements / count));
+        averages.put("scheduleAdherenceRate", round1(sumSchedule / count));
+
+        cacheEmployerReviewSummary(redisKey, averages);
+        return EmployerReviewSummaryResponseDto.fromAverageMap(averages);
     }
 
-    private void cacheEmployerReviewSummary(String redisKey, List<Map<String, Object>> payload) {
+    private void cacheEmployerReviewSummary(String redisKey, Map<String, Object> payload) {
         try {
             redisTemplate.opsForValue().set(redisKey, payload);
         } catch (Exception e) {
@@ -90,6 +107,10 @@ public class EmployerReviewService {
             return number.doubleValue();
         }
         return 0.0;
+    }
+
+    private double round1(double value) {
+        return Math.round(value * 10.0) / 10.0;
     }
 
     public EmployerReputationAiResponseDto getAiReputation(Long userId) {

--- a/freebridge/user/src/main/java/com/fallguys/mypage/service/employer/EmployerReviewService.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/service/employer/EmployerReviewService.java
@@ -3,8 +3,6 @@ package com.fallguys.mypage.service.employer;
 import com.fallguys.common.ai.port.ReviewEngine;
 import com.fallguys.mypage.api.web.dto.employer.response.EmployerReputationAiResponseDto;
 import com.fallguys.mypage.api.web.dto.employer.response.EmployerReviewSummaryResponseDto;
-import com.fallguys.mypage.entity.employer.Employer;
-import com.fallguys.mypage.repository.employer.EmployerRepository;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import lombok.RequiredArgsConstructor;
@@ -23,15 +21,11 @@ import java.util.Map;
 public class EmployerReviewService {
 
     private final RedisTemplate<String, Object> redisTemplate;
-    private final EmployerRepository employerRepository;
     private final EntityManager entityManager;
     private final ReviewEngine reviewEngine;
 
     public EmployerReviewSummaryResponseDto getReputationSummary(Long userId) {
-        Long employerId = resolveEmployerId(userId);
-        if (employerId == null) {
-            return EmployerReviewSummaryResponseDto.empty();
-        }
+        Long employerId = userId;
 
         String redisKey = "employer:review:rates:" + employerId;
         
@@ -88,17 +82,6 @@ public class EmployerReviewService {
             redisTemplate.opsForValue().set(redisKey, payload);
         } catch (Exception e) {
             log.warn("고용주 리뷰 요약을 Redis에 저장하지 못했습니다. key={}", redisKey, e);
-        }
-    }
-
-    private Long resolveEmployerId(Long userId) {
-        try {
-            return employerRepository.findByUserId(userId)
-                    .map(Employer::getEmployerId)
-                    .orElse(null);
-        } catch (Exception e) {
-            log.warn("userId로 employerId를 찾지 못했습니다. userId={}", userId, e);
-            return null;
         }
     }
 

--- a/freebridge/user/src/main/java/com/fallguys/mypage/service/freelancer/FreelancerProfileService.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/service/freelancer/FreelancerProfileService.java
@@ -40,6 +40,7 @@ public class FreelancerProfileService {
     private final FreelancerRepository freelancerRepository;
     private final FileStorage fileStorage;
     private final SharedMypageApi sharedMypageApi;
+    private final FreelancerReviewService freelancerReviewService;
 
     private static final long MAX_AVATAR_BYTES = 5 * 1024 * 1024; // 프로필 이미지 최대 허용 크기 5MB
 
@@ -47,6 +48,7 @@ public class FreelancerProfileService {
     public FreelancerProfileResponseDto getProfile(Long userId) {
         Freelancer freelancer = findByUserIdOrThrow(userId);
         ExternalUserResponse userResponse = sharedMypageApi.getUserById(userId);
+        freelancerReviewService.getReviewSummary(userId);
 
         WorkConditions workConditions = freelancer.getWorkConditions();
         WorkConditionsDto workConditionsDto = workConditions == null ? null : new WorkConditionsDto(


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #

## 📝 작업 내용
백엔드에서 마이페이지 리뷰 캐시와 계약 API 응답 이름 처리 로직을 정리했습니다. 고용주 리뷰 Redis 캐시가 잘못된 ID 기준 또는 비일관된 구조로 저장되던 문제를 수정했고, 계약 API가 mock 사용자명을 반환하던 부분도 실제 사용자명/회사명 기준으로 보완했습니다.

## ✅ Changes
- 계약 API 응답에서 `사용자 #id` mock 이름을 제거하고 실제 사용자명/고용주 회사명을 반환하도록 수정
- `contract` 모듈에서 `user` 모듈을 참조하도록 의존성 추가
- 프리랜서 후기 작성 및 계약 조회 화면에서 사용할 고용주 이름이 실제 회사명 기준으로 내려가도록 계약 응답 로직 보완
- 마이페이지 진입 시 프로필 조회와 함께 리뷰 요약 캐시가 생성되도록 프로필 서비스에서 리뷰 요약 서비스 호출 추가
- `EmployerReviewService`의 리뷰 요약 조회 기준을 고용주 `userId`로 통일해 공란 캐시가 생성되던 문제 수정
- `employer:review:rates:{id}` Redis 캐시를 리뷰 원본 배열이 아닌 항목별 평균값 객체 구조로 변경
- 기존 배열 캐시가 남아 있어도 읽을 수 있도록 호환 처리 추가

## 📸 스크린샷 (선택)
> UI 변경 사항이나 테스트 결과 화면이 있다면 첨부해주세요.
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
- Redis 키는 고정 문자열이 아니라 `freelancer:review:rates:{freelancerId}`, `employer:review:rates:{userId}` 형식입니다.
- `employer` 리뷰 캐시는 이번 변경부터 평균값 객체로 저장되며, 기존 배열 구조도 읽을 수 있게 유지했습니다.
- 계약 API 응답값 변경으로 `/api/contracts`, `/api/contracts/{id}` 를 사용하는 화면의 표시 이름이 함께 달라질 수 있습니다.
- 서버 재기동 후 캐시 재생성 여부를 함께 확인하는 것이 좋습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 고용주 및 프리랜서 프로필에 평판 요약 기능 추가
  * 리뷰 평균 점수 캐싱 기능 구현으로 성능 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->