### PR TITLE
HFP-96 [BE] 고용주 리뷰 저장 시 freelancer_id를 freelancer.user_id 기준으로 정규화

### DIFF
--- a/freebridge/review/src/main/java/com/fallguys/review/service/ReviewServiceImpl.java
+++ b/freebridge/review/src/main/java/com/fallguys/review/service/ReviewServiceImpl.java
@@ -12,6 +12,8 @@ import com.fallguys.review.entity.FreelancerReview;
 import com.fallguys.review.entity.ReviewStatus;
 import com.fallguys.review.repository.EmployerReviewRepository;
 import com.fallguys.review.repository.FreelancerReviewRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -42,6 +44,7 @@ public class ReviewServiceImpl implements ReviewService {
     private final ProjectExternalApi projectExternalApi;
     private final RedisTemplate<String, Object> redisTemplate;
     private final ApplicationEventPublisher eventPublisher;
+    private final EntityManager entityManager;
 
     @Override
     public Page<FreelancerReview> getEmployerReceivedReviews(Long employerId, Pageable pageable) {
@@ -64,23 +67,15 @@ public class ReviewServiceImpl implements ReviewService {
     @Override
     @Transactional
     public Long createEmployerReview(Long employerId, EmployerReviewCreateRequest request) {
-        // 1. 중복 리뷰 체크 로직
-        employerReviewRepository
-                .findByProjectIdAndEmployerIdAndFreelancerIdAndStatus(
-                        request.projectId(),
-                        employerId,
-                        request.freelancerId(),
-                        ReviewStatus.ACTIVE
-                )
-                .ifPresent(review -> {
-                    throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
-                });
+        FreelancerIdentity freelancerIdentity = resolveFreelancerIdentity(request.freelancerId());
+        Long normalizedFreelancerUserId = freelancerIdentity.userId();
 
-        // 2. 리뷰 엔티티 생성
+        assertNoDuplicateEmployerReview(request.projectId(), employerId, normalizedFreelancerUserId);
+
         EmployerReview review = EmployerReview.builder()
                 .projectId(request.projectId())
                 .employerId(employerId)
-                .freelancerId(request.freelancerId())
+                .freelancerId(normalizedFreelancerUserId)
                 .language(request.language())
                 .framework(request.framework())
                 .debugging(request.debugging())
@@ -94,12 +89,12 @@ public class ReviewServiceImpl implements ReviewService {
             EmployerReview savedReview = employerReviewRepository.save(review);
             Long reviewId = savedReview.getId();
 
-            runAfterCommitSafely(() -> invalidateFreelancerReviewCaches(request.freelancerId()));
+            runAfterCommitSafely(() -> invalidateFreelancerReviewCaches(freelancerIdentity));
 
             projectExternalApi.completeProjectWithReview(
                     new ProjectExternalApi.ProjectCompletionData(
                             savedReview.getProjectId(),
-                            savedReview.getFreelancerId(),
+                            request.freelancerId(),
                             savedReview.getDescription(),
                             savedReview.getCommunication() != null ? savedReview.getCommunication() : 0,
                             savedReview.getDebugging() != null ? savedReview.getDebugging() : 0,
@@ -138,7 +133,8 @@ public class ReviewServiceImpl implements ReviewService {
                 request.dispute(),
                 request.description()
         );
-        runAfterCommitSafely(() -> invalidateFreelancerReviewCaches(review.getFreelancerId()));
+        FreelancerIdentity freelancerIdentity = resolveFreelancerIdentity(review.getFreelancerId());
+        runAfterCommitSafely(() -> invalidateFreelancerReviewCaches(freelancerIdentity));
     }
 
     @Override
@@ -151,7 +147,8 @@ public class ReviewServiceImpl implements ReviewService {
                 )
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE));
         review.softDelete();
-        runAfterCommitSafely(() -> invalidateFreelancerReviewCaches(review.getFreelancerId()));
+        FreelancerIdentity freelancerIdentity = resolveFreelancerIdentity(review.getFreelancerId());
+        runAfterCommitSafely(() -> invalidateFreelancerReviewCaches(freelancerIdentity));
     }
 
     @Override
@@ -267,17 +264,76 @@ public class ReviewServiceImpl implements ReviewService {
         deleteRedisValue(EMPLOYER_REVIEW_RATES_KEY_PREFIX + employerId);
     }
 
-    private void invalidateFreelancerReviewCaches(Long freelancerId) {
-        deleteRedisValue(FREELANCER_REVIEW_RATES_KEY_PREFIX + freelancerId);
-        deleteRedisValue("freelancer:review:ai_report:" + freelancerId);
+    private void invalidateFreelancerReviewCaches(FreelancerIdentity freelancerIdentity) {
+        deleteRedisValue(FREELANCER_REVIEW_RATES_KEY_PREFIX + freelancerIdentity.freelancerPk());
+        deleteRedisValue(FREELANCER_REVIEW_RATES_KEY_PREFIX + freelancerIdentity.userId());
+        deleteRedisValue("freelancer:review:ai_report:" + freelancerIdentity.freelancerPk());
+        deleteRedisValue("freelancer:review:ai_report:" + freelancerIdentity.userId());
 
         try {
             eventPublisher.publishEvent(
-                    new com.fallguys.common.event.ReputationUpdateRequestedEvent(freelancerId)
+                    new com.fallguys.common.event.ReputationUpdateRequestedEvent(freelancerIdentity.freelancerPk())
             );
         } catch (RuntimeException e) {
-            log.warn("Failed to publish reputation update event. freelancerId={}", freelancerId, e);
+            log.warn("Failed to publish reputation update event. freelancerId={}", freelancerIdentity.freelancerPk(), e);
         }
+    }
+
+    private void assertNoDuplicateEmployerReview(Long projectId, Long employerId, Long freelancerId) {
+        employerReviewRepository
+                .findByProjectIdAndEmployerIdAndFreelancerIdAndStatus(
+                        projectId,
+                        employerId,
+                        freelancerId,
+                        ReviewStatus.ACTIVE
+                )
+                .ifPresent(review -> {
+                    throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+                });
+    }
+
+    private FreelancerIdentity resolveFreelancerIdentity(Long freelancerReferenceId) {
+        if (freelancerReferenceId == null) {
+            return new FreelancerIdentity(null, null);
+        }
+
+        try {
+            Query query = entityManager.createNativeQuery("""
+                    SELECT freelancer_id, user_id
+                    FROM freelancer
+                    WHERE freelancer_id = :referenceId
+                       OR user_id = :referenceId
+                    LIMIT 1
+                    """);
+            query.setParameter("referenceId", freelancerReferenceId);
+            Object singleResult = query.getSingleResult();
+            if (singleResult instanceof Object[] row && row.length >= 2) {
+                Long freelancerPk = toLong(row[0]);
+                Long userId = toLong(row[1]);
+                return new FreelancerIdentity(
+                        freelancerPk != null ? freelancerPk : freelancerReferenceId,
+                        userId != null ? userId : freelancerReferenceId
+                );
+            }
+        } catch (RuntimeException e) {
+            log.debug("Failed to resolve freelancer identity. freelancerReferenceId={}", freelancerReferenceId, e);
+        }
+
+        return new FreelancerIdentity(freelancerReferenceId, freelancerReferenceId);
+    }
+
+    private Long toLong(Object value) {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        if (value instanceof String text) {
+            try {
+                return Long.parseLong(text);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
     }
 
 
@@ -312,5 +368,8 @@ public class ReviewServiceImpl implements ReviewService {
             current = current.getCause();
         }
         return false;
+    }
+
+    private record FreelancerIdentity(Long freelancerPk, Long userId) {
     }
 }

--- a/freebridge/review/src/test/java/com/fallguys/review/service/ReviewServiceImplTest.java
+++ b/freebridge/review/src/test/java/com/fallguys/review/service/ReviewServiceImplTest.java
@@ -12,6 +12,7 @@ import com.fallguys.review.entity.FreelancerReview;
 import com.fallguys.review.entity.ReviewStatus;
 import com.fallguys.review.repository.EmployerReviewRepository;
 import com.fallguys.review.repository.FreelancerReviewRepository;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,6 +43,9 @@ class ReviewServiceImplTest {
 
     @Mock
     private ProjectExternalApi projectExternalApi;
+
+    @Mock
+    private EntityManager entityManager;
 
     @InjectMocks
     private ReviewServiceImpl reviewService;

--- a/freebridge/review/src/test/java/com/fallguys/review/service/ReviewServiceImplTest.java
+++ b/freebridge/review/src/test/java/com/fallguys/review/service/ReviewServiceImplTest.java
@@ -13,6 +13,8 @@ import com.fallguys.review.entity.ReviewStatus;
 import com.fallguys.review.repository.EmployerReviewRepository;
 import com.fallguys.review.repository.FreelancerReviewRepository;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.Query;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,6 +49,9 @@ class ReviewServiceImplTest {
     @Mock
     private EntityManager entityManager;
 
+    @Mock
+    private Query query;
+
     @InjectMocks
     private ReviewServiceImpl reviewService;
 
@@ -55,9 +60,12 @@ class ReviewServiceImplTest {
     void createEmployerReview_whenAlreadyExists_throwsBusinessException() {
         // given
         Long employerId = 1L;
-        EmployerReviewCreateRequest request = new EmployerReviewCreateRequest(10L, 20L, 5, 5, 5, 5, 5, 5, "desc");
+        Long inputFreelancerPk = 20L;
+        Long normalizedFreelancerUserId = 200L;
+        EmployerReviewCreateRequest request = new EmployerReviewCreateRequest(10L, inputFreelancerPk, 5, 5, 5, 5, 5, 5, "desc");
+        stubFreelancerIdentity(inputFreelancerPk, inputFreelancerPk, normalizedFreelancerUserId);
         when(employerReviewRepository.findByProjectIdAndEmployerIdAndFreelancerIdAndStatus(
-                request.projectId(), employerId, request.freelancerId(), ReviewStatus.ACTIVE
+                request.projectId(), employerId, normalizedFreelancerUserId, ReviewStatus.ACTIVE
         )).thenReturn(Optional.of(EmployerReview.builder().id(99L).build()));
 
         // when
@@ -68,13 +76,16 @@ class ReviewServiceImplTest {
     }
 
     @Test
-    @DisplayName("[TDD] 고용주 리뷰 생성 성공 시 저장된 리뷰 ID를 반환한다")
-    void createEmployerReview_success_returnsSavedId() {
+    @DisplayName("[TDD] 고용주 리뷰 생성 시 freelancer PK 입력은 userId로 정규화되어 저장된다")
+    void createEmployerReview_withFreelancerPk_normalizesToUserId() {
         // given
         Long employerId = 1L;
-        EmployerReviewCreateRequest request = new EmployerReviewCreateRequest(10L, 20L, 4, 4, 4, 4, 4, 4, "good");
+        Long inputFreelancerPk = 20L;
+        Long expectedUserId = 200L;
+        EmployerReviewCreateRequest request = new EmployerReviewCreateRequest(10L, inputFreelancerPk, 4, 4, 4, 4, 4, 4, "good");
+        stubFreelancerIdentity(inputFreelancerPk, inputFreelancerPk, expectedUserId);
         when(employerReviewRepository.findByProjectIdAndEmployerIdAndFreelancerIdAndStatus(
-                request.projectId(), employerId, request.freelancerId(), ReviewStatus.ACTIVE
+                request.projectId(), employerId, expectedUserId, ReviewStatus.ACTIVE
         )).thenReturn(Optional.empty());
         when(employerReviewRepository.save(any())).thenReturn(EmployerReview.builder().id(123L).build());
 
@@ -86,8 +97,56 @@ class ReviewServiceImplTest {
         ArgumentCaptor<EmployerReview> captor = ArgumentCaptor.forClass(EmployerReview.class);
         verify(employerReviewRepository, times(1)).save(captor.capture());
         assertEquals(employerId, captor.getValue().getEmployerId());
-        assertEquals(request.freelancerId(), captor.getValue().getFreelancerId());
+        assertEquals(expectedUserId, captor.getValue().getFreelancerId());
         verify(projectExternalApi, times(1)).completeProjectWithReview(any());
+    }
+
+    @Test
+    @DisplayName("[TDD] 고용주 리뷰 생성 시 이미 userId 입력이면 동일한 값으로 저장된다")
+    void createEmployerReview_withFreelancerUserId_keepsSameIdentity() {
+        // given
+        Long employerId = 1L;
+        Long freelancerUserId = 200L;
+        EmployerReviewCreateRequest request = new EmployerReviewCreateRequest(10L, freelancerUserId, 4, 4, 4, 4, 4, 4, "good");
+        stubFreelancerIdentity(freelancerUserId, freelancerUserId, freelancerUserId);
+        when(employerReviewRepository.findByProjectIdAndEmployerIdAndFreelancerIdAndStatus(
+                request.projectId(), employerId, freelancerUserId, ReviewStatus.ACTIVE
+        )).thenReturn(Optional.empty());
+        when(employerReviewRepository.save(any())).thenReturn(EmployerReview.builder().id(124L).build());
+
+        // when
+        Long reviewId = reviewService.createEmployerReview(employerId, request);
+
+        // then
+        assertEquals(124L, reviewId);
+        ArgumentCaptor<EmployerReview> captor = ArgumentCaptor.forClass(EmployerReview.class);
+        verify(employerReviewRepository).save(captor.capture());
+        assertEquals(freelancerUserId, captor.getValue().getFreelancerId());
+        verify(entityManager).createNativeQuery(any(String.class));
+        verify(query).setParameter("referenceId", freelancerUserId);
+    }
+
+    @Test
+    @DisplayName("[TDD] 고용주 리뷰 생성 시 freelancer 조회 결과가 없으면 입력값으로 폴백한다")
+    void createEmployerReview_whenFreelancerIdentityMissing_fallsBackToInputId() {
+        // given
+        Long employerId = 1L;
+        Long missingFreelancerId = 999L;
+        EmployerReviewCreateRequest request = new EmployerReviewCreateRequest(10L, missingFreelancerId, 4, 4, 4, 4, 4, 4, "good");
+        stubFreelancerIdentityNoResult(missingFreelancerId);
+        when(employerReviewRepository.findByProjectIdAndEmployerIdAndFreelancerIdAndStatus(
+                request.projectId(), employerId, missingFreelancerId, ReviewStatus.ACTIVE
+        )).thenReturn(Optional.empty());
+        when(employerReviewRepository.save(any())).thenReturn(EmployerReview.builder().id(125L).build());
+
+        // when
+        Long reviewId = reviewService.createEmployerReview(employerId, request);
+
+        // then
+        assertEquals(125L, reviewId);
+        ArgumentCaptor<EmployerReview> captor = ArgumentCaptor.forClass(EmployerReview.class);
+        verify(employerReviewRepository).save(captor.capture());
+        assertEquals(missingFreelancerId, captor.getValue().getFreelancerId());
     }
 
     @Test
@@ -95,9 +154,12 @@ class ReviewServiceImplTest {
     void createEmployerReview_duplicateSqlState_throwsBusinessException() {
         // given
         Long employerId = 1L;
-        EmployerReviewCreateRequest request = new EmployerReviewCreateRequest(10L, 20L, 3, 3, 3, 3, 3, 3, "dup");
+        Long inputFreelancerPk = 20L;
+        Long normalizedFreelancerUserId = 200L;
+        EmployerReviewCreateRequest request = new EmployerReviewCreateRequest(10L, inputFreelancerPk, 3, 3, 3, 3, 3, 3, "dup");
+        stubFreelancerIdentity(inputFreelancerPk, inputFreelancerPk, normalizedFreelancerUserId);
         when(employerReviewRepository.findByProjectIdAndEmployerIdAndFreelancerIdAndStatus(
-                request.projectId(), employerId, request.freelancerId(), ReviewStatus.ACTIVE
+                request.projectId(), employerId, normalizedFreelancerUserId, ReviewStatus.ACTIVE
         )).thenReturn(Optional.empty());
         DataIntegrityViolationException ex = new DataIntegrityViolationException(
                 "duplicate", new SQLException("duplicate key", "23505")
@@ -215,5 +277,17 @@ class ReviewServiceImplTest {
         // then
         assertEquals(ReviewStatus.DELETED, review.getStatus());
         assertEquals(true, review.getDeleted());
+    }
+
+    private void stubFreelancerIdentity(Long referenceId, Long freelancerPk, Long userId) {
+        when(entityManager.createNativeQuery(any(String.class))).thenReturn(query);
+        when(query.setParameter("referenceId", referenceId)).thenReturn(query);
+        when(query.getSingleResult()).thenReturn(new Object[]{freelancerPk, userId});
+    }
+
+    private void stubFreelancerIdentityNoResult(Long referenceId) {
+        when(entityManager.createNativeQuery(any(String.class))).thenReturn(query);
+        when(query.setParameter("referenceId", referenceId)).thenReturn(query);
+        when(query.getSingleResult()).thenThrow(new NoResultException());
     }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #

## 📝 작업 내용
고용주가 프리랜서 리뷰를 작성할 때 `review` 테이블의 `freelancer_id`에 프리랜서 PK가 아니라 `freelancer.user_id`가 저장되도록 저장 로직을 수정했습니다. 신규 저장 기준에 맞게 리뷰 조회 및 AI 분석 경로도 동일한 기준만 사용하도록 정리했습니다.

## ✅ Changes
- 고용주 리뷰 생성 시 입력받은 프리랜서 PK를 `freelancer.user_id`로 변환 후 저장하도록 수정
- 리뷰 중복 체크도 저장 기준과 동일하게 `freelancer.user_id` 기준으로 정리
- 프리랜서 리뷰 캐시 무효화 로직을 저장 기준에 맞게 조정
- 프리랜서 리뷰 요약 조회 쿼리를 신규 저장 기준에 맞게 단순화
- AI 평판 분석용 리뷰 조회도 동일 기준으로 정리
- 리뷰 서비스 테스트 검증

## 📸 스크린샷 (선택)
해당 없음

## ⚠️ Notes (Optional)
- 기존 `review` 데이터는 신규 저장 기준과 맞지 않을 수 있어 별도 정리가 필요합니다.
- `:review:test --tests com.fallguys.review.service.ReviewServiceImplTest` 기준으로 검증했습니다.
- `user` 모듈에는 이번 변경과 별개인 기존 컴파일 이슈가 있어 전체 테스트는 확인하지 못했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Refactor**
  * 리뷰 검증 프로세스 개선으로 데이터 일관성 강화
  * 프리랜서 신원 확인 메커니즘 추가로 중복 검사 및 캐시 관리 개선

* **Tests**
  * 백엔드 검증 로직 테스트 커버리지 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->