### PR TITLE
HFP-122 [fix] 채팅방 읽음표시 오류 수정

### DIFF
--- a/freebridge/chatting/src/main/java/com/fallguys/chatting/api/web/ChatRoomController.java
+++ b/freebridge/chatting/src/main/java/com/fallguys/chatting/api/web/ChatRoomController.java
@@ -59,6 +59,15 @@ public class ChatRoomController {
         return ResponseEntity.ok(rooms);
     }
 
+    @PostMapping("/{roomId}/read")
+    public ResponseEntity<ChatRoomResponse> markRoomAsRead(
+            @RequestHeader("Authorization") String authHeader,
+            @PathVariable String roomId) {
+        String userId = extractUserId(authHeader);
+        ChatRoomResponse response = chatRoomService.markRoomAsRead(roomId, userId);
+        return ResponseEntity.ok(response);
+    }
+
     @PostMapping("/{roomId}/leave")
     public ResponseEntity<ChatRoomResponse> leaveRoom(
             @RequestHeader("Authorization") String authHeader,

--- a/freebridge/chatting/src/main/java/com/fallguys/chatting/repository/ChatRoomRepository.java
+++ b/freebridge/chatting/src/main/java/com/fallguys/chatting/repository/ChatRoomRepository.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ChatRoomRepository extends MongoRepository<ChatRoom, String> {
+public interface ChatRoomRepository extends MongoRepository<ChatRoom, String>, ChatRoomRepositoryCustom {
 
     /**
      * 유저가 참여 중인 활성 채팅방 목록 조회

--- a/freebridge/chatting/src/main/java/com/fallguys/chatting/repository/ChatRoomRepositoryCustom.java
+++ b/freebridge/chatting/src/main/java/com/fallguys/chatting/repository/ChatRoomRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.fallguys.chatting.repository;
+
+import com.fallguys.chatting.domain.ChatMessage;
+
+import java.util.Collection;
+
+public interface ChatRoomRepositoryCustom {
+
+    boolean clearUnreadCount(String roomId, String participantId);
+
+    boolean updateMessageState(String roomId, String senderId, ChatMessage lastMessage,
+            Collection<String> unreadRecipients);
+}

--- a/freebridge/chatting/src/main/java/com/fallguys/chatting/repository/ChatRoomRepositoryImpl.java
+++ b/freebridge/chatting/src/main/java/com/fallguys/chatting/repository/ChatRoomRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.fallguys.chatting.repository;
+
+import com.fallguys.chatting.domain.ChatMessage;
+import com.fallguys.chatting.domain.ChatRoom;
+import com.mongodb.client.result.UpdateResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
+
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public boolean clearUnreadCount(String roomId, String participantId) {
+        Query query = new Query(Criteria.where("_id").is(roomId).and("participants").is(participantId));
+        Update update = new Update().set("unreadCount." + participantId, 0);
+        UpdateResult result = mongoTemplate.updateFirst(query, update, ChatRoom.class);
+        return result.getMatchedCount() > 0;
+    }
+
+    @Override
+    public boolean updateMessageState(String roomId, String senderId, ChatMessage lastMessage,
+            Collection<String> unreadRecipients) {
+        Query query = new Query(Criteria.where("_id").is(roomId).and("participants").is(senderId));
+        Update update = new Update()
+                .set("lastMessage", lastMessage)
+                .set("updatedAt", LocalDateTime.now());
+
+        unreadRecipients.forEach(participantId -> update.inc("unreadCount." + participantId, 1));
+
+        UpdateResult result = mongoTemplate.updateFirst(query, update, ChatRoom.class);
+        return result.getMatchedCount() > 0;
+    }
+}

--- a/freebridge/chatting/src/main/java/com/fallguys/chatting/service/ChatMessageService.java
+++ b/freebridge/chatting/src/main/java/com/fallguys/chatting/service/ChatMessageService.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -62,19 +63,15 @@ public class ChatMessageService {
         // 2. MongoDB 저장
         ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
 
-        // 3. 채팅방 마지막 메시지 정보 업데이트
-        room.updateLastMessage(savedMessage);
-
-        // 4. 발송자를 제외한 상대방의 안 읽은 캐시 수 증가 (스트림 내부 횟수 오류 수정)
-        room.incrementUnreadCountForOthers(senderId); // 객체의 카운트 상태 1번만 업데이트
-
-        room.getParticipants().stream()
+        List<String> unreadRecipients = room.getParticipants().stream()
                 .filter(participantId -> !participantId.equals(senderId))
-                .forEach(participantId -> {
-                    unreadMessageRedisRepository.incrementUnreadCount(roomId, participantId);
-                });
+                .toList();
 
-        chatRoomRepository.save(room);
+        if (!chatRoomRepository.updateMessageState(roomId, senderId, savedMessage, unreadRecipients)) {
+            throw new IllegalStateException("메시지 상태를 채팅방에 반영할 수 없습니다: " + roomId);
+        }
+
+        unreadRecipients.forEach(participantId -> unreadMessageRedisRepository.incrementUnreadCount(roomId, participantId));
 
         // 5. Response DTO 생성
         ChatMessageResponse response = ChatMessageResponse.from(savedMessage);
@@ -108,13 +105,16 @@ public class ChatMessageService {
 
         ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
 
-        room.updateLastMessage(savedMessage);
-        room.incrementUnreadCountForOthers(participantId);
-        room.getParticipants().stream()
+        List<String> unreadRecipients = room.getParticipants().stream()
                 .filter(roomParticipantId -> !roomParticipantId.equals(participantId))
-                .forEach(roomParticipantId -> unreadMessageRedisRepository.incrementUnreadCount(room.getId(), roomParticipantId));
+                .toList();
 
-        chatRoomRepository.save(room);
+        if (!chatRoomRepository.updateMessageState(room.getId(), participantId, savedMessage, unreadRecipients)) {
+            throw new IllegalStateException("퇴장 메시지 상태를 채팅방에 반영할 수 없습니다: " + room.getId());
+        }
+
+        unreadRecipients
+                .forEach(roomParticipantId -> unreadMessageRedisRepository.incrementUnreadCount(room.getId(), roomParticipantId));
 
         ChatMessageResponse response = ChatMessageResponse.from(savedMessage);
         redisPublisher.publish(channelTopic, response);
@@ -136,9 +136,10 @@ public class ChatMessageService {
             throw new IllegalArgumentException("채팅방에 접근할 권한이 없습니다.");
         }
 
-        room.resetUnreadCount(userId);
+        if (!chatRoomRepository.clearUnreadCount(roomId, userId)) {
+            throw new IllegalStateException("읽음 상태를 갱신할 수 없습니다: " + roomId);
+        }
         unreadMessageRedisRepository.resetUnreadCount(roomId, userId);
-        chatRoomRepository.save(room);
 
         org.springframework.data.domain.Sort sort = org.springframework.data.domain.Sort.by(
                 org.springframework.data.domain.Sort.Order.desc("createdAt"),

--- a/freebridge/chatting/src/main/java/com/fallguys/chatting/service/ChatMessageService.java
+++ b/freebridge/chatting/src/main/java/com/fallguys/chatting/service/ChatMessageService.java
@@ -136,6 +136,10 @@ public class ChatMessageService {
             throw new IllegalArgumentException("채팅방에 접근할 권한이 없습니다.");
         }
 
+        room.resetUnreadCount(userId);
+        unreadMessageRedisRepository.resetUnreadCount(roomId, userId);
+        chatRoomRepository.save(room);
+
         org.springframework.data.domain.Sort sort = org.springframework.data.domain.Sort.by(
                 org.springframework.data.domain.Sort.Order.desc("createdAt"),
                 org.springframework.data.domain.Sort.Order.desc("_id"));

--- a/freebridge/chatting/src/main/java/com/fallguys/chatting/service/ChatRoomService.java
+++ b/freebridge/chatting/src/main/java/com/fallguys/chatting/service/ChatRoomService.java
@@ -66,11 +66,14 @@ public class ChatRoomService {
             throw new IllegalArgumentException("채팅방에 참여하고 있지 않습니다.");
         }
 
-        room.resetUnreadCount(participantId);
+        if (!chatRoomRepository.clearUnreadCount(roomId, participantId)) {
+            throw new IllegalStateException("읽음 상태를 갱신할 수 없습니다: " + roomId);
+        }
         unreadMessageRedisRepository.resetUnreadCount(roomId, participantId);
 
-        ChatRoom savedRoom = chatRoomRepository.save(room);
-        return ChatRoomResponse.from(savedRoom, buildParticipantPresence(savedRoom));
+        ChatRoom refreshedRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalStateException("읽음 상태가 갱신된 채팅방을 다시 찾을 수 없습니다: " + roomId));
+        return ChatRoomResponse.from(refreshedRoom, buildParticipantPresence(refreshedRoom));
     }
 
     public ChatRoomResponse leaveChatRoom(String roomId, String participantId) {

--- a/freebridge/chatting/src/main/java/com/fallguys/chatting/service/ChatRoomService.java
+++ b/freebridge/chatting/src/main/java/com/fallguys/chatting/service/ChatRoomService.java
@@ -3,6 +3,7 @@ package com.fallguys.chatting.service;
 import com.fallguys.chatting.api.web.dto.response.ChatRoomResponse;
 import com.fallguys.chatting.domain.ChatRoom;
 import com.fallguys.chatting.repository.ChatRoomRepository;
+import com.fallguys.chatting.repository.UnreadMessageRedisRepository;
 import com.fallguys.common.api.contract.ContractQuery;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +24,7 @@ public class ChatRoomService {
     private final ChatPresenceService chatPresenceService;
     private final ChatMessageService chatMessageService;
     private final ContractQuery contractQuery;
+    private final UnreadMessageRedisRepository unreadMessageRedisRepository;
 
     /**
      * 1:1 채팅방 생성 (이미 방이 존재할 경우 기존 방을 반환하는 로직은 추후 추가)
@@ -53,6 +55,22 @@ public class ChatRoomService {
         return rooms.stream()
                 .map(room -> ChatRoomResponse.from(room, buildParticipantPresence(room)))
                 .toList();
+    }
+
+    public ChatRoomResponse markRoomAsRead(String roomId, String participantId) {
+        ChatRoom room = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다: " + roomId));
+
+        if (!room.isParticipant(participantId)) {
+            log.warn("권한 없는 사용자의 채팅방 읽음 처리 시도 - roomId: {}, participantId: {}", roomId, participantId);
+            throw new IllegalArgumentException("채팅방에 참여하고 있지 않습니다.");
+        }
+
+        room.resetUnreadCount(participantId);
+        unreadMessageRedisRepository.resetUnreadCount(roomId, participantId);
+
+        ChatRoom savedRoom = chatRoomRepository.save(room);
+        return ChatRoomResponse.from(savedRoom, buildParticipantPresence(savedRoom));
     }
 
     public ChatRoomResponse leaveChatRoom(String roomId, String participantId) {

--- a/freebridge/chatting/src/test/java/com/fallguys/chatting/service/ChatMessageServiceTest.java
+++ b/freebridge/chatting/src/test/java/com/fallguys/chatting/service/ChatMessageServiceTest.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -58,6 +59,8 @@ class ChatMessageServiceTest {
                                 .build();
 
                 when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(savedMsg);
+                when(chatRoomRepository.updateMessageState(eq("room1"), eq("e1"), eq(savedMsg), anyList()))
+                                .thenReturn(true);
 
                 // when
                 ChatMessageResponse response = chatMessageService.sendMessage("room1", "e1", "안녕하세요", MessageType.TEXT,
@@ -68,6 +71,7 @@ class ChatMessageServiceTest {
 
                 // Redis Publisher 가 불렸는지 검증
                 verify(redisPublisher, times(1)).publish(any(), any());
+                verify(chatRoomRepository, times(1)).updateMessageState(eq("room1"), eq("e1"), eq(savedMsg), anyList());
 
                 // 안 읽은 메시지 수 캐시 증가가 불렸는지 검증 (수신자 f1에 대해)
                 verify(unreadMessageRedisRepository, times(1)).incrementUnreadCount("room1", "f1");
@@ -85,6 +89,7 @@ class ChatMessageServiceTest {
 
                 when(chatMessageRepository.findByRoomIdOrderByCreatedAtDesc(eq("room1"), any()))
                                 .thenReturn(List.of(msg2, msg1));
+                when(chatRoomRepository.clearUnreadCount("room1", "e1")).thenReturn(true);
 
                 // when
                 CursorPageResponse<ChatMessageResponse> response = chatMessageService

--- a/freebridge/contract/src/main/java/com/fallguys/contract/service/ContractQueryService.java
+++ b/freebridge/contract/src/main/java/com/fallguys/contract/service/ContractQueryService.java
@@ -21,7 +21,7 @@ public class ContractQueryService implements ContractQuery {
         return contractRepository.existsByContractId(contractId);
     }
 
-    @Override
+    @Override 
     public ContractInfo getContractInfo(Long contractId) {
         var c = contractRepository.findByContractId(contractId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CONTRACT_NOT_FOUND));


### PR DESCRIPTION
## 🔗 Related Issue
> 이슈 번호를 작성해주세요. (예: Closes #123)
- Closes #204 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
수정은 두 군데에 넣었습니다. 백엔드에 채팅방 읽음 처리 API를 추가, 
메시지 조회 시에도 unreadCount를 서버에서 0으로 리셋하도록 수정
## ✅ Changes
> 주요 변경 사항을 bullet point로 정리합니다.

## 📸 스크린샷 (선택)
> UI 변경 사항이나 테스트 결과 화면이 있다면 첨부해주세요.
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
> 리뷰 시 유의할 점, 후속 PR 예정 사항, 배포 영향 등을 적습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새 기능**
  * 채팅방을 읽음으로 표시하는 기능 추가 (읽음 처리용 API)
  * 메시지 조회 시 해당 사용자의 미읽음 카운트 자동 초기화

* **동작 개선**
  * 여러 수신자 대상 미읽음 반영 방식 개선으로 미읽음 카운트와 마지막 메시지 상태가 보다 일관되게 갱신됩니다
<!-- end of auto-generated comment: release notes by coderabbit.ai -->