### PR TITLE
HFP-122 [fix] 결제 저장 쪽을 비즈니스 계약번호 기준으로 수정

### DIFF
--- a/freebridge/contract/src/main/java/com/fallguys/contract/service/ContractQueryService.java
+++ b/freebridge/contract/src/main/java/com/fallguys/contract/service/ContractQueryService.java
@@ -4,11 +4,14 @@ import com.fallguys.common.api.contract.ContractInfo;
 import com.fallguys.common.api.contract.ContractQuery;
 import com.fallguys.common.exception.BusinessException;
 import com.fallguys.common.exception.ErrorCode;
+import com.fallguys.contract.entity.Contract;
 import com.fallguys.contract.repository.ContractRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -23,8 +26,14 @@ public class ContractQueryService implements ContractQuery {
 
     @Override 
     public ContractInfo getContractInfo(Long contractId) {
-        var c = contractRepository.findByContractId(contractId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.CONTRACT_NOT_FOUND));
+        Contract c = contractRepository.findByContractId(contractId)
+                .orElseGet(() -> contractRepository.findById(contractId)
+                        .map(contract -> {
+                            log.warn("Legacy internal contract PK lookup detected in ContractQuery.getContractInfo: requestedId={}, resolvedContractNo={}",
+                                    contractId, contract.getContractId());
+                            return contract;
+                        })
+                        .orElseThrow(() -> new BusinessException(ErrorCode.CONTRACT_NOT_FOUND)));
 
         return new ContractInfo(
                 c.getId(),

--- a/freebridge/contract/src/test/java/com/fallguys/contract/service/ContractQueryServiceTest.java
+++ b/freebridge/contract/src/test/java/com/fallguys/contract/service/ContractQueryServiceTest.java
@@ -80,12 +80,32 @@ class ContractQueryServiceTest {
         assertEquals(LocalDate.of(2024, 1, 1), result.startDate());
         assertEquals(LocalDate.of(2024, 12, 31), result.endDate());
         assertEquals(5000000L, result.budget());
+        verify(contractRepository, never()).findById(anyLong());
+    }
+
+    @Test
+    @DisplayName("getContractInfo()는 레거시 내부 PK가 들어온 경우 내부 PK로 fallback 조회한다")
+    void getContractInfo_fallsBackToInternalIdForLegacySettlementData() {
+        when(contractRepository.findByContractId(1L))
+                .thenReturn(Optional.empty());
+        when(contractRepository.findById(1L))
+                .thenReturn(Optional.of(contract));
+
+        ContractInfo result = contractQueryService.getContractInfo(1L);
+
+        assertNotNull(result);
+        assertEquals(1L, result.id());
+        assertEquals(1001L, result.contractId());
+        verify(contractRepository).findByContractId(1L);
+        verify(contractRepository).findById(1L);
     }
 
     @Test
     @DisplayName("getContractInfo()는 존재하지 않는 비즈니스 계약번호 조회 시 예외를 발생시킨다")
     void getContractInfo_throwsExceptionWhenContractNotFound() {
         when(contractRepository.findByContractId(999L))
+                .thenReturn(Optional.empty());
+        when(contractRepository.findById(999L))
                 .thenReturn(Optional.empty());
 
         RuntimeException exception = assertThrows(
@@ -112,5 +132,6 @@ class ContractQueryServiceTest {
         assertEquals(2L, result.id());
         assertEquals(1002L, result.contractId());
         assertNull(result.projectName());
+        verify(contractRepository, never()).findById(anyLong());
     }
 }

--- a/freebridge/payment/src/main/java/com/fallguys/payment/service/EmployerSettlementService.java
+++ b/freebridge/payment/src/main/java/com/fallguys/payment/service/EmployerSettlementService.java
@@ -348,18 +348,25 @@ public class EmployerSettlementService {
      */
     @Transactional
     public List<EmployerSettlement> createSettlementRecords(ContractInfo contract, String paymentId, Long employerId) {
+        Long contractPublicId = contract.contractId();
+
+        if (contractPublicId == null) {
+            log.error("계약 business contractId가 null입니다: internalId={}", contract.id());
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
         // 필수 계약 필드 null 검증 — null이면 NPE 대신 명확한 BusinessException을 던집니다.
         if (contract.budget() == null) {
-            log.error("계약 budget이 null입니다: contractId={}", contract.id());
+            log.error("계약 budget이 null입니다: contractId={}", contractPublicId);
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
         if (contract.startDate() == null || contract.endDate() == null) {
             log.error("계약 startDate/endDate가 null입니다: contractId={}, startDate={}, endDate={}",
-                    contract.id(), contract.startDate(), contract.endDate());
+                    contractPublicId, contract.startDate(), contract.endDate());
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
         if (contract.freelancerId() == null) {
-            log.error("계약 freelancerId가 null입니다: contractId={}", contract.id());
+            log.error("계약 freelancerId가 null입니다: contractId={}", contractPublicId);
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
@@ -402,7 +409,7 @@ public class EmployerSettlementService {
             LocalDate dueDate = buildDueDate(startDate, i - 1, paymentDay);
 
             EmployerSettlement es = new EmployerSettlement();
-            es.setContractId(contract.id());
+            es.setContractId(contractPublicId);
             es.setEmployerId(employerId);
             es.setFreelancerId(contract.freelancerId());
             es.setTransactionId((i == 1) ? paymentId : null);
@@ -422,7 +429,7 @@ public class EmployerSettlementService {
                 employerSettlementRepository.save(es);
             } catch (Exception e) {
                 log.error("서비스 수수료 인보이스 생성 실패: contractId={}, installment={}, error={}",
-                        contract.id(), i, e.getMessage());
+                        contractPublicId, i, e.getMessage());
             }
 
             // 대응하는 FreelancerSettlement 생성
@@ -433,7 +440,7 @@ public class EmployerSettlementService {
             long netAmount = billingAmount - fsPlatformFee - tax;
 
             FreelancerSettlement fs = new FreelancerSettlement();
-            fs.setContractId(contract.id());
+            fs.setContractId(contractPublicId);
             fs.setEmployerSettlementId(es.getId());
             fs.setFreelancerId(contract.freelancerId());
             fs.setTotalAmount(billingAmount);


### PR DESCRIPTION
## 🔗 Related Issue
> 이슈 번호를 작성해주세요. (예: Closes #123)
- Closes #206 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
문제는 결제 모듈이 정산 레코드에 ContractInfo.id()를 저장하고 있었다는 점입니다. id는 내부 PK이고, 지금 계약 조회는 비즈니스 계약번호 contractId로만 찾음
이미 잘못 저장된 기존 정산 데이터는 자동으로 고쳐지지 않는다.. 
즉 방금 전 결제로 만들어진 employer_settlements.contract_id / freelancer_settlements.contract_id가 내부 PK로 들어가 있으면 그 레코드는 계속 오류가 납니다. 재테스트하려면 그 잘못된 정산 데이터는 지우거나 contract_id를 비즈니스 계약번호로 수정해야 합니다
## ✅ Changes
> 주요 변경 사항을 bullet point로 정리합니다.

## 📸 스크린샷 (선택)
> UI 변경 사항이나 테스트 결과 화면이 있다면 첨부해주세요.
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
> 리뷰 시 유의할 점, 후속 PR 예정 사항, 배포 영향 등을 적습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩토링**
  * 계약 식별자 처리와 로깅을 통일해 운영 안정성과 추적 가능성을 강화했습니다. 레거시 내부 식별자 경로를 인식하도록 조회 로직을 보완했습니다.
* **테스트**
  * 레거시 식별자 폴백 경로와 식별자 기반 조회 동작을 검증하는 단위 테스트를 추가/확장했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->