### PR TITLE
HFP-120 [fix] profile preview API 안정화 및 freelancer resume 상세 응답 추가

### DIFF
--- a/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/employer/response/EmployerProfilePreviewResponseDto.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/employer/response/EmployerProfilePreviewResponseDto.java
@@ -1,0 +1,14 @@
+package com.fallguys.mypage.api.web.dto.employer.response;
+
+public record EmployerProfilePreviewResponseDto(
+        Long employerId,
+        Long userId,
+        String companyName,
+        String industry,
+        String scale,
+        String location,
+        String websiteUrl,
+        String phone,
+        String description,
+        String logoUrl
+) {}

--- a/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/freelancer/response/FreelancerPreviewCareerDto.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/freelancer/response/FreelancerPreviewCareerDto.java
@@ -1,0 +1,14 @@
+package com.fallguys.mypage.api.web.dto.freelancer.response;
+
+import java.time.LocalDate;
+
+public record FreelancerPreviewCareerDto(
+        String companyName,
+        String department,
+        String position,
+        String jobType,
+        String employmentType,
+        LocalDate startDate,
+        LocalDate endDate,
+        String description
+) {}

--- a/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/freelancer/response/FreelancerPreviewCertificationDto.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/freelancer/response/FreelancerPreviewCertificationDto.java
@@ -1,0 +1,9 @@
+package com.fallguys.mypage.api.web.dto.freelancer.response;
+
+import java.time.LocalDate;
+
+public record FreelancerPreviewCertificationDto(
+        String name,
+        String issuer,
+        LocalDate acquisitionDate
+) {}

--- a/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/freelancer/response/FreelancerPreviewEducationDto.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/freelancer/response/FreelancerPreviewEducationDto.java
@@ -1,0 +1,12 @@
+package com.fallguys.mypage.api.web.dto.freelancer.response;
+
+import java.time.LocalDate;
+
+public record FreelancerPreviewEducationDto(
+        String schoolType,
+        String schoolName,
+        String major,
+        String status,
+        LocalDate entranceDate,
+        LocalDate graduationDate
+) {}

--- a/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/freelancer/response/FreelancerProfilePreviewResponseDto.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/freelancer/response/FreelancerProfilePreviewResponseDto.java
@@ -19,6 +19,9 @@ public record FreelancerProfilePreviewResponseDto(
         String phone,
         String email,
         String address,
+        List<FreelancerPreviewEducationDto> educations,
+        List<FreelancerPreviewCareerDto> careers,
+        List<FreelancerPreviewCertificationDto> certifications,
         String portfolioFileUrl,
         String portfolioFileName,
         LocalDateTime portfolioLastUpdated

--- a/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/freelancer/response/FreelancerProfilePreviewResponseDto.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/api/web/dto/freelancer/response/FreelancerProfilePreviewResponseDto.java
@@ -1,0 +1,25 @@
+package com.fallguys.mypage.api.web.dto.freelancer.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record FreelancerProfilePreviewResponseDto(
+        Long freelancerId,
+        Long userId,
+        String name,
+        String avatarUrl,
+        String job,
+        String introduction,
+        String grade,
+        Integer careerYears,
+        Long wage,
+        List<String> skills,
+        LocalDate birthDate,
+        String phone,
+        String email,
+        String address,
+        String portfolioFileUrl,
+        String portfolioFileName,
+        LocalDateTime portfolioLastUpdated
+) {}

--- a/freebridge/user/src/main/java/com/fallguys/mypage/api/web/employer/EmployerFreelancerProfilePreviewController.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/api/web/employer/EmployerFreelancerProfilePreviewController.java
@@ -1,0 +1,23 @@
+package com.fallguys.mypage.api.web.employer;
+
+import com.fallguys.common.response.ApiResponse;
+import com.fallguys.mypage.api.web.dto.freelancer.response.FreelancerProfilePreviewResponseDto;
+import com.fallguys.mypage.service.ProfilePreviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/employer/freelancers")
+public class EmployerFreelancerProfilePreviewController {
+
+    private final ProfilePreviewService profilePreviewService;
+
+    @GetMapping("/{freelancerId}/preview")
+    public ApiResponse<FreelancerProfilePreviewResponseDto> getFreelancerPreview(@PathVariable Long freelancerId) {
+        return ApiResponse.ok(profilePreviewService.getFreelancerPreview(freelancerId));
+    }
+}

--- a/freebridge/user/src/main/java/com/fallguys/mypage/api/web/freelancer/FreelancerEmployerProfilePreviewController.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/api/web/freelancer/FreelancerEmployerProfilePreviewController.java
@@ -1,0 +1,23 @@
+package com.fallguys.mypage.api.web.freelancer;
+
+import com.fallguys.common.response.ApiResponse;
+import com.fallguys.mypage.api.web.dto.employer.response.EmployerProfilePreviewResponseDto;
+import com.fallguys.mypage.service.ProfilePreviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/freelancer/employers")
+public class FreelancerEmployerProfilePreviewController {
+
+    private final ProfilePreviewService profilePreviewService;
+
+    @GetMapping("/{employerId}/preview")
+    public ApiResponse<EmployerProfilePreviewResponseDto> getEmployerPreview(@PathVariable Long employerId) {
+        return ApiResponse.ok(profilePreviewService.getEmployerPreview(employerId));
+    }
+}

--- a/freebridge/user/src/main/java/com/fallguys/mypage/service/ProfilePreviewService.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/service/ProfilePreviewService.java
@@ -1,0 +1,86 @@
+package com.fallguys.mypage.service;
+
+import com.fallguys.mypage.api.shared.SharedMypageApi;
+import com.fallguys.mypage.api.web.dto.employer.response.EmployerProfilePreviewResponseDto;
+import com.fallguys.mypage.api.web.dto.freelancer.response.FreelancerProfilePreviewResponseDto;
+import com.fallguys.mypage.entity.employer.Employer;
+import com.fallguys.mypage.entity.freelancer.Freelancer;
+import com.fallguys.mypage.entity.freelancer.PortfolioInfo;
+import com.fallguys.mypage.entity.resume.Resume;
+import com.fallguys.mypage.repository.employer.EmployerRepository;
+import com.fallguys.mypage.repository.freelancer.FreelancerRepository;
+import com.fallguys.mypage.repository.resume.ResumeRepository;
+import com.fallguys.user.api.shared.ExternalUserApi;
+import com.fallguys.user.api.shared.response.ExternalUserMyInfoResponse;
+import com.fallguys.user.api.shared.response.ExternalUserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProfilePreviewService {
+
+    private final EmployerRepository employerRepository;
+    private final FreelancerRepository freelancerRepository;
+    private final ResumeRepository resumeRepository;
+    private final ExternalUserApi externalUserApi;
+    private final SharedMypageApi sharedMypageApi;
+
+    @Transactional(readOnly = true)
+    public EmployerProfilePreviewResponseDto getEmployerPreview(Long employerId) {
+        Employer employer = employerRepository.findById(employerId)
+                .orElseThrow(() -> new IllegalArgumentException("Employer profile not found"));
+
+        ExternalUserMyInfoResponse userInfo = null;
+        try {
+            userInfo = externalUserApi.getMyInfo(employer.getUserId());
+        } catch (Exception ignored) {
+        }
+
+        return new EmployerProfilePreviewResponseDto(
+                employer.getEmployerId(),
+                employer.getUserId(),
+                employer.getCompanyName(),
+                employer.getIndustry(),
+                employer.getScale() != null ? employer.getScale().name() : null,
+                employer.getLocation(),
+                employer.getWebsiteUrl(),
+                userInfo != null ? userInfo.getPhone() : null,
+                employer.getDescription(),
+                employer.getLogoUrl()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public FreelancerProfilePreviewResponseDto getFreelancerPreview(Long freelancerId) {
+        Freelancer freelancer = freelancerRepository.findById(freelancerId)
+                .orElseThrow(() -> new IllegalArgumentException("Freelancer profile not found"));
+
+        ExternalUserResponse user = sharedMypageApi.getUserById(freelancer.getUserId());
+        Resume resume = resumeRepository.findByFreelancerId(freelancerId).orElse(null);
+        PortfolioInfo portfolio = freelancer.getPortfolioInfo();
+
+        return new FreelancerProfilePreviewResponseDto(
+                freelancer.getFreelancerId(),
+                freelancer.getUserId(),
+                user != null ? user.getName() : null,
+                freelancer.getAvatarUrl(),
+                freelancer.getJob(),
+                freelancer.getIntroduction(),
+                freelancer.getGrade() != null ? freelancer.getGrade().name() : null,
+                freelancer.getCareerYears(),
+                freelancer.getWage(),
+                freelancer.getSkills() == null ? List.of() : freelancer.getSkills(),
+                resume != null ? resume.getBirthDate() : null,
+                resume != null ? resume.getPhone() : null,
+                resume != null ? resume.getEmail() : null,
+                resume != null ? resume.getAddress() : null,
+                portfolio != null ? portfolio.getPortfolioFileUrl() : null,
+                portfolio != null ? portfolio.getPortfolioFileName() : null,
+                portfolio != null ? portfolio.getPortfolioLastUpdated() : null
+        );
+    }
+}

--- a/freebridge/user/src/main/java/com/fallguys/mypage/service/ProfilePreviewService.java
+++ b/freebridge/user/src/main/java/com/fallguys/mypage/service/ProfilePreviewService.java
@@ -2,10 +2,16 @@ package com.fallguys.mypage.service;
 
 import com.fallguys.mypage.api.shared.SharedMypageApi;
 import com.fallguys.mypage.api.web.dto.employer.response.EmployerProfilePreviewResponseDto;
+import com.fallguys.mypage.api.web.dto.freelancer.response.FreelancerPreviewCareerDto;
+import com.fallguys.mypage.api.web.dto.freelancer.response.FreelancerPreviewCertificationDto;
+import com.fallguys.mypage.api.web.dto.freelancer.response.FreelancerPreviewEducationDto;
 import com.fallguys.mypage.api.web.dto.freelancer.response.FreelancerProfilePreviewResponseDto;
 import com.fallguys.mypage.entity.employer.Employer;
 import com.fallguys.mypage.entity.freelancer.Freelancer;
 import com.fallguys.mypage.entity.freelancer.PortfolioInfo;
+import com.fallguys.mypage.entity.resume.Career;
+import com.fallguys.mypage.entity.resume.Certification;
+import com.fallguys.mypage.entity.resume.Education;
 import com.fallguys.mypage.entity.resume.Resume;
 import com.fallguys.mypage.repository.employer.EmployerRepository;
 import com.fallguys.mypage.repository.freelancer.FreelancerRepository;
@@ -32,7 +38,29 @@ public class ProfilePreviewService {
     @Transactional(readOnly = true)
     public EmployerProfilePreviewResponseDto getEmployerPreview(Long employerId) {
         Employer employer = employerRepository.findById(employerId)
-                .orElseThrow(() -> new IllegalArgumentException("Employer profile not found"));
+                .or(() -> employerRepository.findByUserId(employerId))
+                .orElse(null);
+
+        if (employer == null) {
+            ExternalUserResponse user = null;
+            try {
+                user = sharedMypageApi.getUserById(employerId);
+            } catch (Exception ignored) {
+            }
+
+            return new EmployerProfilePreviewResponseDto(
+                    null,
+                    employerId,
+                    user != null ? user.getName() : "기업 정보 없음",
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+        }
 
         ExternalUserMyInfoResponse userInfo = null;
         try {
@@ -57,10 +85,18 @@ public class ProfilePreviewService {
     @Transactional(readOnly = true)
     public FreelancerProfilePreviewResponseDto getFreelancerPreview(Long freelancerId) {
         Freelancer freelancer = freelancerRepository.findById(freelancerId)
+                .or(() -> freelancerRepository.findByUserId(freelancerId))
                 .orElseThrow(() -> new IllegalArgumentException("Freelancer profile not found"));
 
-        ExternalUserResponse user = sharedMypageApi.getUserById(freelancer.getUserId());
+        ExternalUserResponse user = null;
+        try {
+            user = sharedMypageApi.getUserById(freelancer.getUserId());
+        } catch (Exception ignored) {
+        }
         Resume resume = resumeRepository.findByFreelancerId(freelancerId).orElse(null);
+        if (resume == null) {
+            resume = resumeRepository.findByUserId(freelancer.getUserId()).orElse(null);
+        }
         PortfolioInfo portfolio = freelancer.getPortfolioInfo();
 
         return new FreelancerProfilePreviewResponseDto(
@@ -78,9 +114,62 @@ public class ProfilePreviewService {
                 resume != null ? resume.getPhone() : null,
                 resume != null ? resume.getEmail() : null,
                 resume != null ? resume.getAddress() : null,
+                resume != null ? mapEducations(resume.getEducations()) : List.of(),
+                resume != null ? mapCareers(resume.getCareers()) : List.of(),
+                resume != null ? mapCertifications(resume.getCertifications()) : List.of(),
                 portfolio != null ? portfolio.getPortfolioFileUrl() : null,
                 portfolio != null ? portfolio.getPortfolioFileName() : null,
                 portfolio != null ? portfolio.getPortfolioLastUpdated() : null
         );
+    }
+
+    private List<FreelancerPreviewEducationDto> mapEducations(List<Education> educations) {
+        if (educations == null || educations.isEmpty()) {
+            return List.of();
+        }
+
+        return educations.stream()
+                .map(education -> new FreelancerPreviewEducationDto(
+                        education.getSchoolType(),
+                        education.getSchoolName(),
+                        education.getMajor(),
+                        education.getEduStatus() != null ? education.getEduStatus().name() : null,
+                        education.getEntranceDate(),
+                        education.getGraduationDate()
+                ))
+                .toList();
+    }
+
+    private List<FreelancerPreviewCareerDto> mapCareers(List<Career> careers) {
+        if (careers == null || careers.isEmpty()) {
+            return List.of();
+        }
+
+        return careers.stream()
+                .map(career -> new FreelancerPreviewCareerDto(
+                        career.getCompanyName(),
+                        career.getDepartment(),
+                        career.getPosition(),
+                        career.getJobType(),
+                        career.getEmploymentType(),
+                        career.getStartDate(),
+                        career.getEndDate(),
+                        career.getDescription()
+                ))
+                .toList();
+    }
+
+    private List<FreelancerPreviewCertificationDto> mapCertifications(List<Certification> certifications) {
+        if (certifications == null || certifications.isEmpty()) {
+            return List.of();
+        }
+
+        return certifications.stream()
+                .map(certification -> new FreelancerPreviewCertificationDto(
+                        certification.getName(),
+                        certification.getIssuer(),
+                        certification.getAcquisitionDate()
+                ))
+                .toList();
     }
 }


### PR DESCRIPTION
## 🔗 Related Issue
> 이슈 번호를 작성해주세요. (예: Closes #123)
- Closes #213 

## 📝 작업 내용
profile preview API 안정화 및 freelancer resume 상세 응답 추가


## ✅ Changes

- employer profile preview 조회 시 employerId / userId fallback 조회 지원
- employer preview 조회 실패 시 500 대신 최소 정보 응답으로 방어
- freelancer profile preview 응답에 Resume 학력/경력/자격증 정보 추가
- freelancer preview 전용 DTO 분리
  - education
  - career
  - certification
- 기존 preview API를 FE 프로필 모달 요구사항에 맞게 확장


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 고용주가 프리랜서 프로필 미리보기를 조회할 수 있는 API 엔드포인트 추가
  * 프리랜서가 고용주 프로필 미리보기를 조회할 수 있는 API 엔드포인트 추가
  * 프로필 미리보기에 교육, 경력, 자격증 정보 포함

<!-- end of auto-generated comment: release notes by coderabbit.ai -->